### PR TITLE
Fix: Refactor code, remove library functions

### DIFF
--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -31,7 +31,7 @@ jobs:
           egress-policy: audit
 
       # yamllint disable-line rule:line-length
-      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683  # v4.2.2
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8  # v5.0.0
 
       - name: 'Verify Pushed Tag'
         # yamllint disable-line rule:line-length

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -31,7 +31,7 @@ jobs:
           egress-policy: 'audit'
 
       - name: 'Checkout repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: 'Run comprehensive test suite'
         run: |
@@ -47,13 +47,15 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: 'Checkout sample project repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
         with:
           repository: 'lfreleng-actions/test-python-project'
           path: 'test-python-project'
+
+      # yamllint disable rule:line-length
 
       - name: 'Test External Project'
         id: test-external
@@ -64,7 +66,11 @@ jobs:
       - name: 'Validate External Project Output'
         run: |
           echo "Build Python: '${{ steps.test-external.outputs.build_python }}'"
-          echo "Matrix JSON: '${{ steps.test-external.outputs.matrix_json }}'"
+
+          # Use the raw matrix_json output and compact it with jq for consistent comparison
+          actual_json=$(echo '${{ steps.test-external.outputs.matrix_json }}' | jq -c .)
+          echo "Matrix JSON: '$actual_json'"
+
           # Validate that outputs are not empty
           if [ -z "${{ steps.test-external.outputs.build_python }}" ]; then
             echo "Error: build_python output is empty"
@@ -75,6 +81,36 @@ jobs:
             exit 1
           fi
 
+          # Validate matrix_json contains only valid Python versions (no text values)
+          # Extract the python-version array and check each element is a valid version number
+          # yamllint disable-line rule:line-length
+          if ! echo "$actual_json" | jq -e '.["python-version"] | type == "array"' >/dev/null; then
+            echo "Error: matrix_json does not contain a python-version array"
+            exit 1
+          fi
+
+          # Check that all array elements are valid version strings (X.Y format)
+          # yamllint disable-line rule:line-length
+          invalid_versions=$(echo "$actual_json" | jq -r '.["python-version"][] | select(test("^[0-9]+\\.[0-9]+$") | not)')
+          if [ -n "$invalid_versions" ]; then
+            echo "Error: matrix_json contains invalid version entries:"
+            echo "$invalid_versions"
+            echo "Expected format: only numeric versions like '3.11', '3.12'"
+            exit 1
+          fi
+
+          # For test-python-project, we expect Python 3.11 and 3.12 based on requires-python = "<3.13,>=3.11"
+          # yamllint disable-line rule:line-length
+          expected_json='{"python-version":["3.11","3.12"]}'
+          if [ "$expected_json" != "$actual_json" ]; then
+            echo "Error: matrix_json mismatch for test-python-project"
+            echo "Expected: $expected_json"
+            echo "Actual:   $actual_json"
+            exit 1
+          fi
+
+          echo "External repository test passed ✅"
+
   ### Test Missing pyproject.toml ###
   test-missing-pyproject:
     name: 'Test Missing pyproject.toml'
@@ -84,7 +120,7 @@ jobs:
     timeout-minutes: 8
     steps:
       - name: 'Checkout repository'
-        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
       - name: 'Create empty test directory'
         run: mkdir -p empty-test-dir
@@ -103,3 +139,75 @@ jobs:
             exit 1
           fi
           echo "Test correctly failed due to missing pyproject.toml"
+
+  ### Test Poetry Fixtures ###
+  test-poetry-fixtures:
+    name: 'Test Poetry Fixtures'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: poetry-caret
+            file: tests/fixtures/pyproject_poetry_caret.toml
+            expected_versions: "3.10 3.11 3.12 3.13"
+            expected_build: "3.13"
+          - name: poetry-compatible
+            file: tests/fixtures/pyproject_poetry_compatible.toml
+            expected_versions: "3.11"
+            expected_build: "3.11"
+          - name: poetry-exact
+            file: tests/fixtures/pyproject_poetry_exact.toml
+            expected_versions: "3.12"
+            expected_build: "3.12"
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: 'Prepare fixture workspace'
+        run: |
+          set -euo pipefail
+          workdir="poetry-fixture-${{ matrix.name }}"
+          mkdir -p "$workdir"
+          cp "${{ matrix.file }}" "$workdir/pyproject.toml"
+          echo "WORKDIR=$workdir" >> "$GITHUB_ENV"
+
+      - name: 'Run action on Poetry fixture (offline)'
+        id: run
+        uses: ./
+        with:
+          path_prefix: '${{ env.WORKDIR }}/'
+          offline_mode: 'true'
+
+      - name: 'Assert outputs for Poetry fixture'
+        # yamllint disable rule:line-length
+        run: |
+          echo "Supported versions: '${{ steps.run.outputs.supported_versions }}'"
+          echo "Build Python: '${{ steps.run.outputs.build_python }}'"
+
+          # Use the raw matrix_json output and compact it with jq for consistent comparison
+          actual_json=$(echo '${{ steps.run.outputs.matrix_json }}' | jq -c .)
+          echo "Matrix JSON: '$actual_json'"
+
+          if [ "${{ steps.run.outputs.build_python }}" != "${{ matrix.expected_build }}" ]; then
+            echo "Error: build_python mismatch (expected '${{ matrix.expected_build }}')"
+            exit 1
+          fi
+          if [ "${{ steps.run.outputs.supported_versions }}" != "${{ matrix.expected_versions }}" ]; then
+            echo "Error: supported_versions mismatch (expected '${{ matrix.expected_versions }}')"
+            exit 1
+          fi
+
+          # Construct expected JSON using jq to ensure formatting matches
+          expected_json=$(printf '%s\n' "${{ matrix.expected_versions }}" | tr ' ' '\n' | jq -R . | jq -s -c '{"python-version": .}')
+
+          if [ "$expected_json" != "$actual_json" ]; then
+            echo "Error: matrix_json mismatch"
+            echo "Expected: $expected_json"
+            echo "Actual:   $actual_json"
+            exit 1
+          fi
+          echo "Poetry fixture '${{ matrix.name }}' passed ✅"

--- a/action.yaml
+++ b/action.yaml
@@ -19,34 +19,81 @@ inputs:
   path_prefix:
     description: "Directory location containing project code"
     required: false
+    default: '.'
   network_timeout:
     description: "Network timeout in seconds for API calls"
     required: false
-    default: '10'
+    default: '6'
   max_retries:
     description: "Maximum number of retry attempts for API calls"
     required: false
     default: '2'
+  eol_behaviour:
+    description: "How to handle EOL Python versions: warn|strip|fail"
+    required: false
+    default: 'warn'
+  offline_mode:
+    description: "Disable network lookups and use internal version list only"
+    required: false
+    default: 'false'
 
 outputs:
   build_python:
     description: "Most recent Python version supported by project"
-    value: "${{ steps.parse.outputs.build_python }}"
+    value: "${{ steps.versions.outputs.build_python }}"
   matrix_json:
     description: "All Python versions supported by project as JSON string"
     # Example: matrix_json = {"python-version": ["3.10", "3.11"]}
-    value: "${{ steps.parse.outputs.matrix_json }}"
+    value: "${{ steps.versions.outputs.matrix_json }}"
+  supported_versions:
+    description: "Space-separated list of all supported Python versions"
+    value: "${{ steps.versions.outputs.supported_versions }}"
 
 runs:
   using: "composite"
   steps:
-    - name: "Setup and validate environment"
+    - id: versions
+      name: "Process and determine supported Python versions"
       shell: "bash"
+      env:
+        INPUT_PATH_PREFIX: ${{ inputs.path_prefix }}
+        INPUT_NETWORK_TIMEOUT: ${{ inputs.network_timeout }}
+        INPUT_MAX_RETRIES: ${{ inputs.max_retries }}
+        INPUT_EOL_BEHAVIOUR: ${{ inputs.eol_behaviour }}
+        INPUT_OFFLINE_MODE: ${{ inputs.offline_mode }}
+      # yamllint disable rule:line-length
       run: |
+        # Process and determine supported Python versions
+        set -euo pipefail
+
+        PYPROJECT_FILE="${INPUT_PATH_PREFIX}/pyproject.toml"
+        TIMEOUT="${INPUT_NETWORK_TIMEOUT}"
+        RETRIES="${INPUT_MAX_RETRIES}"
+        EOL_BEHAVIOUR="${INPUT_EOL_BEHAVIOUR}"
+        OFFLINE_MODE="${INPUT_OFFLINE_MODE}"
+
+
+        # Internal list of supported Python versions (requires periodic update)
+        INTERNAL_SUPPORTED_VERSIONS="3.9 3.10 3.11 3.12 3.13"
+
         # Setup and validate environment
-        path_prefix="${{ inputs.path_prefix }}"
+        path_prefix="${INPUT_PATH_PREFIX}"
         path_prefix="${path_prefix:-'.'}"
         path_prefix="${path_prefix%/}"
+
+        # Check tool availability
+        if ! command -v jq >/dev/null 2>&1; then
+          echo 'Error: jq is required but not available. Please install jq or use a runner with jq pre-installed ❌'
+          exit 1
+        fi
+
+        if [[ "$OFFLINE_MODE" != "true" ]]; then
+          if ! command -v curl >/dev/null 2>&1; then
+            echo 'Error: curl is required but not available ❌'
+            exit 1
+          fi
+        fi
+
 
         # Validate directory and pyproject.toml existence
         if [[ ! -d "$path_prefix" ]]; then
@@ -59,130 +106,732 @@ runs:
           exit 1
         fi
 
-        echo "path_prefix=$path_prefix" >> "$GITHUB_ENV"
-        echo "network_timeout=${{ inputs.network_timeout }}" >> "$GITHUB_ENV"
-        echo "max_retries=${{ inputs.max_retries }}" >> "$GITHUB_ENV"
-
-    - name: "Fetch supported Python versions with EOL awareness"
-      shell: "bash"
-      run: |
-        # Fetch supported Python versions with EOL awareness
-        set -o pipefail
-
-        # Configuration
-        TIMEOUT="${{ env.network_timeout }}"
-        RETRIES="${{ env.max_retries }}"
-
-        # Source shared EOL utility functions
-        # shellcheck source=lib/eol_utils.sh
-        source "$GITHUB_ACTION_PATH/lib/eol_utils.sh"
-
-        # Source shared constraint parsing utilities
-        # shellcheck source=lib/constraint_utils.sh
-        source "$GITHUB_ACTION_PATH/lib/constraint_utils.sh"
-
-        # Main version fetching logic
-        echo 'Fetching valid/supported Python versions'
-
-        if PYTHON_VERSIONS=$(fetch_eol_aware_versions \
-          "$TIMEOUT" "$RETRIES"); then
-          echo "all_supported_versions=$PYTHON_VERSIONS" >> "$GITHUB_ENV"
-          echo 'versions_source=dynamic-eol-aware' >> "$GITHUB_ENV"
-        else
-          echo "⚠️  API unavailable, using static fallback versions"
-          STATIC_VERSIONS=$(get_static_python_versions)
-          echo "all_supported_versions=$STATIC_VERSIONS" >> "$GITHUB_ENV"
-          echo 'versions_source=static' >> "$GITHUB_ENV"
+        # Validate eol_behaviour input
+        if [[ "$EOL_BEHAVIOUR" != "warn" && "$EOL_BEHAVIOUR" != "strip" && \
+              "$EOL_BEHAVIOUR" != "fail" ]]; then
+          echo 'Error: eol_behaviour must be one of: warn, strip, fail ❌'
+          exit 1
         fi
 
-    - name: "Extract Python version constraints"
-      shell: "bash"
-      run: |
-        # Extract Python version constraints from pyproject.toml
-        PYPROJECT_FILE="${{ env.path_prefix }}/pyproject.toml"
-
-        # Source shared constraint parsing utilities
-        # shellcheck source=lib/constraint_utils.sh
-        source "$GITHUB_ACTION_PATH/lib/constraint_utils.sh"
-
-        # Extract requires-python constraint using shared utility
-        if REQUIRES_PYTHON=$(extract_requires_python_constraint \
-          "$PYPROJECT_FILE"); then
-          echo "📋 Found requires-python constraint: $REQUIRES_PYTHON"
-          echo "requires_python=$REQUIRES_PYTHON" >> "$GITHUB_ENV"
-        else
-          echo "requires_python=" >> "$GITHUB_ENV"
+        # Validate offline_mode input
+        if [[ "$OFFLINE_MODE" != "true" && "$OFFLINE_MODE" != "false" ]]; then
+          echo 'Error: offline_mode must be true or false ❌'
+          exit 1
         fi
 
-        # Extract classifiers fallback using shared utility
+        # Validate numeric inputs for network timeout and max retries
+        if ! [[ "$TIMEOUT" =~ ^[0-9]+$ ]]; then
+          echo 'Error: network_timeout must be a non-negative integer ❌'
+          exit 1
+        fi
+        if ! [[ "$RETRIES" =~ ^[0-9]+$ ]]; then
+          echo 'Error: max_retries must be a non-negative integer ❌'
+          exit 1
+        fi
+
+        # Function: Portable version comparison (major.minor format)
+        version_compare() {
+            local v1="$1"
+            local op="$2"
+            local v2="$3"
+
+            # Split versions into major.minor
+            local v1_major="${v1%%.*}"
+            local v1_minor="${v1##*.}"
+            local v2_major="${v2%%.*}"
+            local v2_minor="${v2##*.}"
+
+            # Convert to integers for comparison
+            v1_major=$((v1_major))
+            v1_minor=$((v1_minor))
+            v2_major=$((v2_major))
+            v2_minor=$((v2_minor))
+
+            case "$op" in
+                "lt")
+                    [[ $v1_major -lt $v2_major ]] || \
+                    [[ $v1_major -eq $v2_major && $v1_minor -lt $v2_minor ]]
+                    ;;
+                "le")
+                    [[ $v1_major -lt $v2_major ]] || \
+                    [[ $v1_major -eq $v2_major && $v1_minor -le $v2_minor ]]
+                    ;;
+                "gt")
+                    [[ $v1_major -gt $v2_major ]] || \
+                    [[ $v1_major -eq $v2_major && $v1_minor -gt $v2_minor ]]
+                    ;;
+                "ge")
+                    [[ $v1_major -gt $v2_major ]] || \
+                    [[ $v1_major -eq $v2_major && $v1_minor -ge $v2_minor ]]
+                    ;;
+                "eq")
+                    [[ $v1_major -eq $v2_major && $v1_minor -eq $v2_minor ]]
+                    ;;
+                *)
+                    echo "Invalid comparison operator: $op" >&2
+                    return 1
+                    ;;
+            esac
+        }
+
+        # Function: Portable version sorting
+        sort_versions() {
+            local versions="$1"
+            # Use numeric sort on major and minor parts, then join back to space-separated string
+            printf '%s\n' "$versions" | tr ' ' '\n' | sort -t. -k1,1n -k2,2n | tr '\n' ' ' | sed 's/ $//'
+        }
+
+        # Function: Fetch Python EOL data and optionally format as version list
+        fetch_python_data() {
+            local timeout="$1"
+            local retries="$2"
+            local format="${3:-raw}"  # Default to raw format
+            local eol_data
+
+            if [[ "$OFFLINE_MODE" == "true" ]]; then
+                if [[ "$format" == "versions" ]]; then
+                    printf '%s\n' "$INTERNAL_SUPPORTED_VERSIONS"
+                else
+                    echo "[]"  # Empty array for offline mode
+                fi
+                return 0
+            fi
+
+            # Fetch data with error checking
+            # Determine if curl supports --retry-all-errors; fallback if not
+            local curl_retry_flag=""
+            if curl --help 2>/dev/null | grep -q -- '--retry-all-errors'; then
+                curl_retry_flag="--retry-all-errors"
+            fi
+            if eol_data=$(curl -s --max-time "$timeout" --retry "$retries" $curl_retry_flag 'https://endoflife.date/api/python.json' 2>/dev/null); then
+                # Verify we got valid JSON array with expected structure
+                if [[ -n "$eol_data" ]] && echo "$eol_data" | jq -e 'type=="array" and length>0 and all(.[]; has("cycle"))' >/dev/null 2>&1; then
+                    if [[ "$format" == "versions" ]]; then
+                        # Return processed version list (3.9+)
+                        printf '%s\n' "$eol_data" | \
+                          jq -r '.[] | select(.cycle | test("^(3\\.(9|[1-9][0-9])|[4-9][0-9]*\\.[0-9]+)$")) | .cycle' | \
+                          tr '\n' ' ' | sed 's/ $//'
+                    else
+                        # Return raw JSON data
+                        echo "$eol_data"
+                    fi
+                    return 0
+                else
+                    echo "Error: Invalid or empty EOL data received" >&2
+                    return 1
+                fi
+            else
+                echo "Error: Failed to fetch EOL data from API" >&2
+                return 1
+            fi
+        }
+
+        # Function: Check if a version is EOL
+        check_version_eol() {
+            local version="$1"
+            local eol_data="$2"
+            local current_date eol_date eol_type
+
+            if [[ "$OFFLINE_MODE" == "true" ]]; then
+                echo "false"
+                return 0
+            fi
+
+            current_date=$(date +%Y-%m-%d)
+
+            # Extract EOL date for the specific version, handling different types
+            local eol_info
+            eol_info=$(printf '%s\n' "$eol_data" | \
+              jq -r --arg ver "$version" \
+              '.[] | select(.cycle == $ver) | {eol: .eol, type: (.eol | type)}' 2>/dev/null)
+
+            if [[ -z "$eol_info" || "$eol_info" == "null" ]]; then
+                echo "false"
+                return 0
+            fi
+
+            eol_date=$(echo "$eol_info" | jq -r '.eol // "null"')
+            eol_type=$(echo "$eol_info" | jq -r '.type')
+
+            # Handle different EOL field types
+            case "$eol_type" in
+                "string")
+                    if [[ "$eol_date" != "null" && "$eol_date" != "" ]]; then
+                        if [[ "$eol_date" < "$current_date" || "$eol_date" == "$current_date" ]]; then
+                            echo "$eol_date"
+                        else
+                            echo "false"
+                        fi
+                    else
+                        echo "false"
+                    fi
+                    ;;
+                "boolean")
+                    # If EOL is boolean true, it's EOL (no specific date)
+                    if [[ "$eol_date" == "true" ]]; then
+                        echo "true"
+                    else
+                        echo "false"
+                    fi
+                    ;;
+                *)
+                    echo "false"
+                    ;;
+            esac
+        }
+
+        # Function: Normalize constraint (handle ~= and ^ operators)
+        normalize_constraint() {
+            local constraint="$1"
+
+            # Leave exclusions untouched so the parser can handle them precisely
+            if [[ "$constraint" == \!* ]]; then
+                echo "$constraint"
+                return 0
+            fi
+
+            # Handle Poetry caret constraints with patch: ^3.10.1 -> >=3.10,<4.0
+            if [[ "$constraint" =~ ^\^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local next_major=$((major + 1))
+                echo ">=${major}.${minor},<${next_major}.0"
+                return 0
+            fi
+
+            # Handle Poetry caret constraints: ^3.10 -> >=3.10,<4.0
+            if [[ "$constraint" =~ ^\^([0-9]+)\.([0-9]+)$ ]]; then
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local next_major=$((major + 1))
+                echo ">=${major}.${minor},<${next_major}.0"
+                return 0
+            fi
+
+            # Handle compatible release with patch: ~=3.10.1 -> >=3.10,<3.11
+            if [[ "$constraint" =~ ^~=([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local next_minor=$((minor + 1))
+                echo ">=${major}.${minor},<${major}.${next_minor}"
+                return 0
+            fi
+
+            # Handle compatible release: ~=3.10 -> >=3.10,<3.11
+            if [[ "$constraint" =~ ^~=([0-9]+)\.([0-9]+)$ ]]; then
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local next_minor=$((minor + 1))
+                echo ">=${major}.${minor},<${major}.${next_minor}"
+                return 0
+            fi
+
+            # Handle wildcard constraints: ==3.10.* -> >=3.10,<3.11
+            if [[ "$constraint" =~ ^==([0-9]+)\.([0-9]+)\.\*$ ]]; then
+                local major="${BASH_REMATCH[1]}"
+                local minor="${BASH_REMATCH[2]}"
+                local next_minor=$((minor + 1))
+                echo ">=${major}.${minor},<${major}.${next_minor}"
+                return 0
+            fi
+
+            # Strip patch versions from bounds: <3.13.0 -> <3.13 (does not affect '!=')
+            constraint=$(echo "$constraint" | sed 's/\([<>=]\+\)\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1\2/g')
+
+            # Return normalized constraint
+            echo "$constraint"
+        }
+
+        # Function: Extract requires-python constraint from pyproject.toml using Python
+        extract_requires_python_python() {
+            local pyproject_file="$1"
+
+            if [[ ! -f "$pyproject_file" ]]; then
+                return 1
+            fi
+
+            # Try using Python with tomllib (Python 3.11+) or tomli
+            python3 -c "import sys, importlib.util as iu; fp=sys.argv[1]; tmod='tomllib' if iu.find_spec('tomllib') else ('tomli' if iu.find_spec('tomli') else 'toml'); t=__import__(tmod); data=t.load(open(fp, 'rb' if tmod!='toml' else 'r')); v=(data.get('project', {}).get('requires-python') or data.get('tool', {}).get('poetry', {}).get('dependencies', {}).get('python')); print(v) if v else None; sys.exit(0 if v else 1)" "$pyproject_file" 2>/dev/null
+        }
+
+        # Function: Extract requires-python constraint from pyproject.toml (fallback)
+        extract_requires_python_fallback() {
+            local pyproject_file="$1"
+            local constraint
+
+            if [[ ! -f "$pyproject_file" ]]; then
+                return 1
+            fi
+
+            # Extract requires-python constraint, supporting both single and double quotes
+            # Ignore commented lines
+            constraint=$(grep -v '^[[:space:]]*#' "$pyproject_file" 2>/dev/null | \
+                         grep 'requires-python.*=' | \
+                         sed -E 's/.*requires-python.*=[[:space:]]*['\''"]([^'\''"]*)['\''"].*/\1/' | \
+                         head -1)
+
+            if [[ -n "$constraint" ]]; then
+                printf '%s\n' "$constraint"
+                return 0
+            fi
+
+            # Fall back to Poetry python dependency (robust section parsing)
+            constraint=$(awk '
+              BEGIN{insec=0}
+              /^\[tool\.poetry\.dependencies\]/{insec=1; next}
+              /^\[.*\]/{if(insec) exit}
+              insec{print}
+            ' "$pyproject_file" 2>/dev/null | grep -v '^[[:space:]]*#' | grep -E '^[[:space:]]*python[[:space:]]*=' | sed -E 's/.*=[[:space:]]*['\''"]([^'\''"]*)['\''"].*/\1/' | head -1)
+
+            if [[ -n "$constraint" ]]; then
+                printf '%s\n' "$constraint"
+                return 0
+            else
+                return 1
+            fi
+        }
+
+        # Function: Extract Programming Language classifiers from pyproject.toml
+        extract_classifiers_fallback() {
+            local pyproject_file="$1"
+            local classifiers
+
+            if [[ ! -f "$pyproject_file" ]]; then
+                return 1
+            fi
+
+            # Extract Python versions from Programming Language classifiers
+            # Support both single and double quotes, ignore commented lines
+            classifiers=$(grep -v '^[[:space:]]*#' "$pyproject_file" 2>/dev/null | \
+                          grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+' | \
+                          grep -oE '[0-9]+\.[0-9]+' | \
+                          sort -u | tr '\n' ' ' | sed 's/ *$//')
+
+            if [[ -n "$classifiers" ]]; then
+                printf '%s\n' "$classifiers"
+                return 0
+            else
+                return 1
+            fi
+        }
+
+        # Function: Parse version constraint and return all matching versions
+        parse_version_constraint() {
+            local constraint="$1"
+            local all_versions="$2"
+            local result=''
+
+            # Normalize the constraint first
+            constraint=$(normalize_constraint "$constraint")
+
+            # Handle complex constraints with multiple parts (e.g., ">=3.11,<3.13")
+            if [[ "$constraint" == *","* ]]; then
+                local candidates="$all_versions"
+
+                # Split by comma and process each constraint part
+                local IFS=','
+                local -a parts
+                read -ra parts <<< "$constraint"
+                unset IFS
+
+                for part in "${parts[@]}"; do
+                    # Trim whitespace
+                    part=$(echo "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
+                    local temp_result=''
+
+                    case "$part" in
+                        \>=*)
+                            local min_version="${part#>=}"
+                            for version in $candidates; do
+                                if version_compare "$version" "ge" "$min_version"; then
+                                    temp_result="$temp_result $version"
+                                fi
+                            done
+                            ;;
+                        \>*)
+                            local min_version="${part#>}"
+                            for version in $candidates; do
+                                if version_compare "$version" "gt" "$min_version"; then
+                                    temp_result="$temp_result $version"
+                                fi
+                            done
+                            ;;
+                        \<=*)
+                            local max_version="${part#<=}"
+                            for version in $candidates; do
+                                if version_compare "$version" "le" "$max_version"; then
+                                    temp_result="$temp_result $version"
+                                fi
+                            done
+                            ;;
+                        \<*)
+                            local max_version="${part#<}"
+                            for version in $candidates; do
+                                if version_compare "$version" "lt" "$max_version"; then
+                                    temp_result="$temp_result $version"
+                                fi
+                            done
+                            ;;
+                        ==*)
+                            local exact_version="${part#==}"
+                            for version in $candidates; do
+                                if version_compare "$version" "eq" "$exact_version"; then
+                                    temp_result="$version"
+                                    break
+                                fi
+                            done
+                            ;;
+                        \!\=*)
+                            local exclude_raw="${part#!=}"
+                            local exclude_target=""
+                            if [[ "$exclude_raw" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                                exclude_target="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                            else
+                                exclude_target="$exclude_raw"
+                            fi
+                            for version in $candidates; do
+                                if ! version_compare "$version" "eq" "$exclude_target"; then
+                                    temp_result="$temp_result $version"
+                                fi
+                            done
+                            ;;
+                        *)
+                            echo "Warning: Unsupported constraint part: $part" >&2
+                            return 1
+                            ;;
+                    esac
+
+                    # Update candidates to be the filtered result
+                    if [[ -n "$temp_result" ]]; then
+                        candidates=$(echo "$temp_result" | tr ' ' '\n' | grep -v '^$' | \
+                                   sort -u | tr '\n' ' ' | sed 's/ *$//')
+                    else
+                        candidates=''
+                        break  # No matches found, no point continuing
+                    fi
+                done
+
+                result="$candidates"
+            else
+                # Handle simple constraints
+                case "$constraint" in
+                    \>=*)
+                        local min_version="${constraint#>=}"
+                        for version in $all_versions; do
+                            if version_compare "$version" "ge" "$min_version"; then
+                                result="$result $version"
+                            fi
+                        done
+                        ;;
+                    \>*)
+                        local min_version="${constraint#>}"
+                        for version in $all_versions; do
+                            if version_compare "$version" "gt" "$min_version"; then
+                                result="$result $version"
+                            fi
+                        done
+                        ;;
+                    \<=*)
+                        local max_version="${constraint#<=}"
+                        for version in $all_versions; do
+                            if version_compare "$version" "le" "$max_version"; then
+                                result="$result $version"
+                            fi
+                        done
+                        ;;
+                    \<*)
+                        local max_version="${constraint#<}"
+                        for version in $all_versions; do
+                            if version_compare "$version" "lt" "$max_version"; then
+                                result="$result $version"
+                            fi
+                        done
+                        ;;
+                    ==*)
+                        local exact_version="${constraint#==}"
+                        for version in $all_versions; do
+                            if version_compare "$version" "eq" "$exact_version"; then
+                                result="$version"
+                                break
+                            fi
+                        done
+                        ;;
+                    \!\=*)
+                        local exclude_raw="${constraint#!=}"
+                        local exclude_target=""
+                        if [[ "$exclude_raw" =~ ^([0-9]+)\.([0-9]+) ]]; then
+                            exclude_target="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                        else
+                            exclude_target="$exclude_raw"
+                        fi
+                        for version in $all_versions; do
+                            if ! version_compare "$version" "eq" "$exclude_target"; then
+                                result="$result $version"
+                            fi
+                        done
+                        ;;
+                    *)
+                        echo "Warning: Unsupported constraint format: $constraint" >&2
+                        return 1
+                        ;;
+                esac
+            fi
+
+            # Clean up, sort, and return result
+            result=$(printf '%s\n' "$result" | sed 's/^ *//' | sed 's/ *$//')
+            if [[ -n "$result" ]]; then
+                # Ensure final result is properly sorted
+                result=$(sort_versions "$result")
+                printf '%s\n' "$result"
+                return 0
+            else
+                return 1
+            fi
+        }
+
+        # Function: Handle EOL versions based on behaviour setting
+        handle_eol_versions() {
+            local requested_versions="$1"
+            local eol_behaviour="$2"
+            local timeout="$3"
+            local retries="$4"
+            local final_versions=""
+            local eol_data
+
+            if [[ "$OFFLINE_MODE" == "true" ]]; then
+                [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "⚠️ Warning: Offline mode enabled, EOL filtering disabled" >> "$GITHUB_STEP_SUMMARY"
+                printf '%s\n' "$requested_versions"
+                return 0
+            fi
+
+            # Fetch EOL data once
+            if ! eol_data=$(fetch_python_data "$timeout" "$retries" "raw"); then
+              echo "⚠️ Warning: Could not fetch EOL data, proceeding with all requested versions" >&2
+              [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "⚠️ Warning: EOL filtering disabled due to API failure" >> "$GITHUB_STEP_SUMMARY"
+              printf '%s\n' "$requested_versions"
+              return 0
+            fi
+
+            echo "✅ Successfully fetched EOL data for version filtering" >&2
+
+            # Process each version individually
+            for version in $requested_versions; do
+                local eol_result
+                eol_result=$(check_version_eol "$version" "$eol_data")
+
+                if [[ "$eol_result" != "false" ]]; then
+                    # This version is EOL
+                    case "$eol_behaviour" in
+                        "warn")
+                            local message
+                            if [[ "$eol_result" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                              message="⚠️ Warning: Python $version is EOL (end-of-life date: $eol_result)"
+                            else
+                              message="⚠️ Warning: Python $version is EOL"
+                            fi
+                            echo "$message" >&2
+                            [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$message" >> "$GITHUB_STEP_SUMMARY"
+                            # Include this version in final list
+                            final_versions="$final_versions $version"
+                            ;;
+                        "strip")
+                            local message
+                            if [[ "$eol_result" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                              message="⚠️ Warning: Python $version is EOL (end-of-life date: $eol_result) - removing from matrix"
+                            else
+                              message="⚠️ Warning: Python $version is EOL - removing from matrix"
+                            fi
+                            echo "$message" >&2
+                            [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$message" >> "$GITHUB_STEP_SUMMARY"
+                            # Do not include this version in final list
+                            ;;
+                        "fail")
+                            local message
+                            if [[ "$eol_result" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+                              message="🛑 Error: Python $version is EOL (end-of-life date: $eol_result)"
+                            else
+                              message="🛑 Error: Python $version is EOL"
+                            fi
+                            echo "$message" >&2
+                            [ -n "${GITHUB_STEP_SUMMARY:-}" ] && echo "$message" >> "$GITHUB_STEP_SUMMARY"
+                            exit 1
+                            ;;
+                    esac
+                else
+                    # This version is not EOL, include it
+                    final_versions="$final_versions $version"
+                fi
+            done
+
+            # Clean up whitespace and return
+            final_versions=$(echo "$final_versions" | sed 's/^ *//' | sed 's/ *$//')
+            printf '%s\n' "$final_versions"
+        }
+
+        # Function: Generate matrix JSON from space-separated version list
+        generate_matrix_json() {
+            local versions="$1"
+
+            if [[ -z "$versions" ]]; then
+                echo '{"python-version": []}'
+                return 0
+            fi
+
+            # Use jq to properly construct JSON array
+            echo "$versions" | tr ' ' '\n' | jq -R . | jq -s -c '{"python-version": .}'
+        }
+
+        # Function: Get the latest/build version from a list of versions
+        get_build_version() {
+            local versions="$1"
+
+            if [[ -z "$versions" ]]; then
+                return 1
+            fi
+
+            # Sort and get the last (highest) version
+            local sorted_versions
+            sorted_versions=$(sort_versions "$versions")
+            echo "$sorted_versions" | tr ' ' '\n' | tail -1
+        }
+
+        # Function: Validate that all versions have correct format
+        validate_version_format() {
+            local versions="$1"
+
+            for version in $versions; do
+                if [[ ! "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
+                    echo "Invalid version format: '$version'" >&2
+                    return 1
+                fi
+            done
+
+            return 0
+        }
+
+        # Function: Validate JSON format using jq
+        validate_json_format() {
+            local json="$1"
+
+            if echo "$json" | jq -e . >/dev/null 2>&1; then
+                return 0
+            else
+                return 1
+            fi
+        }
+
+        ### Main execution starts here ###
+
+        # Get supported Python versions
+        if SUPPORTED_VERSIONS=$(fetch_python_data "$TIMEOUT" "$RETRIES" "versions"); then
+          if [[ "$OFFLINE_MODE" == "true" ]]; then
+              echo "Using internal supported Python versions (offline mode) 📴"
+          else
+              echo "Retrieved supported Python versions from API service 🌍"
+          fi
+        else
+          echo "Unable to retrieve supported Python versions, using internal list ⚠️"
+          SUPPORTED_VERSIONS="$INTERNAL_SUPPORTED_VERSIONS"
+        fi
+        echo "Supported versions: $SUPPORTED_VERSIONS"
+
+        # Extract requires-python constraint
+        REQUIRES_PYTHON=""
+        if command -v python3 >/dev/null 2>&1; then
+            if REQUIRES_PYTHON=$(extract_requires_python_python "$PYPROJECT_FILE"); then
+              echo "Found requires-python constraint (via Python): $REQUIRES_PYTHON"
+            fi
+        fi
+
+        # Fall back to grep/sed parsing if Python parsing failed
+        if [[ -z "$REQUIRES_PYTHON" ]]; then
+            if REQUIRES_PYTHON=$(extract_requires_python_fallback "$PYPROJECT_FILE"); then
+              echo "Found requires-python constraint (via fallback): $REQUIRES_PYTHON"
+            fi
+        fi
+
+        # Extract classifiers fallback
+        CLASSIFIERS=""
         if CLASSIFIERS=$(extract_classifiers_fallback "$PYPROJECT_FILE"); then
-          echo "📋 Found Programming Language classifiers: $CLASSIFIERS"
-          echo "classifiers=$CLASSIFIERS" >> "$GITHUB_ENV"
-        else
-          echo "classifiers=" >> "$GITHUB_ENV"
+          echo "Programming Language classifiers: $CLASSIFIERS"
         fi
 
         # Check if any constraints were found
         if [[ -z "$REQUIRES_PYTHON" && -z "$CLASSIFIERS" ]]; then
-          echo "⚠️  No Python version constraints found"
+          echo "Error: No Python version constraints found in $PYPROJECT_FILE ❌"
+          exit 1
         fi
 
-    - id: parse
-      name: "Process and determine supported Python versions"
-      shell: "bash"
-      run: |
-        # Process and transform extracted Python versions using shared utilities
-        set -o pipefail
+        # Process constraints and determine requested versions
+        REQUESTED_PYTHON_VERSIONS=""
 
-        ALL_SUPPORTED_VERSIONS="${{ env.all_supported_versions }}"
-        VERSIONS_SOURCE="${{ env.versions_source }}"
-        PYPROJECT_FILE="${{ env.path_prefix }}/pyproject.toml"
+        # Try requires-python first
+        if [[ -n "$REQUIRES_PYTHON" ]]; then
+            if REQUESTED_PYTHON_VERSIONS=$(parse_version_constraint "$REQUIRES_PYTHON" "$SUPPORTED_VERSIONS"); then
+                echo "🔍 Processed requires-python constraint successfully"
+                # Clean up whitespace
+                REQUESTED_PYTHON_VERSIONS=$(echo "$REQUESTED_PYTHON_VERSIONS" | sed 's/^ *//' | sed 's/ *$//')
+            fi
+        fi
 
-        # Source shared constraint parsing utilities
-        # shellcheck source=lib/constraint_utils.sh
-        source "$GITHUB_ACTION_PATH/lib/constraint_utils.sh"
+        # Fall back to classifiers if no versions from requires-python
+        if [[ -z "$REQUESTED_PYTHON_VERSIONS" && -n "$CLASSIFIERS" ]]; then
+            REQUESTED_PYTHON_VERSIONS="$CLASSIFIERS"
+            echo "Using Programming Language classifiers fallback ⏪"
+        fi
 
-        # Use shared utility to process Python constraints
-        if PYTHON_VERSIONS=$(process_python_constraints "$PYPROJECT_FILE" \
-                           "$ALL_SUPPORTED_VERSIONS"); then
-          echo "🔍 Processed Python version constraints successfully"
+        # Validate results
+        if [[ -z "$REQUESTED_PYTHON_VERSIONS" ]]; then
+            echo "Error: Failed to determine Python versions from constraints ❌"
+            exit 1
+        fi
+
+        if ! validate_version_format "$REQUESTED_PYTHON_VERSIONS"; then
+            echo "Error: Invalid version format detected ❌"
+            echo "Versions: $REQUESTED_PYTHON_VERSIONS"
+            exit 1
+        fi
+
+        echo "Python versions from constraints: $REQUESTED_PYTHON_VERSIONS"
+
+        # Handle EOL versions based on eol_behaviour setting
+        FINAL_PYTHON_VERSIONS=$(handle_eol_versions "$REQUESTED_PYTHON_VERSIONS" "$EOL_BEHAVIOUR" "$TIMEOUT" "$RETRIES")
+
+        # Validate final results
+        if [[ -z "$FINAL_PYTHON_VERSIONS" ]]; then
+            echo "Error: No supported Python versions after EOL processing ❌"
+            exit 1
+        fi
+
+        # Sort and clean final versions
+        FINAL_PYTHON_VERSIONS=$(sort_versions "$FINAL_PYTHON_VERSIONS")
+
+        # Generate build version and matrix JSON
+        if BUILD_PYTHON=$(get_build_version "$FINAL_PYTHON_VERSIONS"); then
+          echo "Build Python: $BUILD_PYTHON"
         else
-          echo "❌ Failed to determine Python versions from constraints"
+          echo "Error: Failed to determine build Python version ❌"
           exit 1
         fi
 
-        # Generate build version and matrix JSON using shared utilities
-        if BUILD_PYTHON=$(get_build_version "$PYTHON_VERSIONS"); then
-          echo "🐍 Build Python determined: $BUILD_PYTHON"
+        if MATRIX_JSON=$(generate_matrix_json "$FINAL_PYTHON_VERSIONS") && \
+          validate_json_format "$MATRIX_JSON"; then
+          echo "Matrix JSON generated successfully"
         else
-          echo "❌ Failed to determine build Python version"
-          exit 1
-        fi
-
-        if MATRIX_JSON=$(generate_matrix_json "$PYTHON_VERSIONS"); then
-          echo "🔧 Matrix JSON generated successfully"
-        else
-          echo "❌ Failed to generate matrix JSON"
-          exit 1
-        fi
-
-        # Final validation using shared utilities
-        if ! validate_version_format "$PYTHON_VERSIONS"; then
-          echo "❌ Invalid version format detected in: $PYTHON_VERSIONS"
-          exit 1
-        fi
-
-        if ! validate_json_format "$MATRIX_JSON"; then
-          echo "❌ Generated invalid JSON format"
+          echo "Error: Failed to generate matrix JSON ❌"
           exit 1
         fi
 
         # Set outputs
         echo "build_python=$BUILD_PYTHON" >> "$GITHUB_OUTPUT"
-        echo "matrix_json=$MATRIX_JSON" >> "$GITHUB_OUTPUT"
+        {
+          echo "matrix_json<<__PY_MATRIX_JSON__"
+          echo "$MATRIX_JSON"
+          echo "__PY_MATRIX_JSON__"
+        } >> "$GITHUB_OUTPUT"
+        echo "supported_versions=$FINAL_PYTHON_VERSIONS" >> "$GITHUB_OUTPUT"
 
         # Final clean output
-        echo "✅ Python version analysis complete"
-        echo "🐍 Build Python: $BUILD_PYTHON"
-        echo "📊 Supported versions: $PYTHON_VERSIONS"
-        echo "🔧 Matrix JSON: $MATRIX_JSON"
+        echo "✅ Build Python: $BUILD_PYTHON"
+        echo "✅ Supported versions: $FINAL_PYTHON_VERSIONS"
+        echo "✅ Matrix JSON: $MATRIX_JSON"

--- a/lib/constraint_utils.sh
+++ b/lib/constraint_utils.sh
@@ -1,346 +1,355 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
-# Shared utility functions for Python version constraint parsing
-# This script provides common functionality used by both the main action
-# and test scripts to avoid code duplication and ensure consistency.
+# Shared constraint parsing utilities used by tests and action logic.
+# This library intentionally avoids external tool dependencies beyond
+# standard POSIX utilities (grep, sed, awk) to keep tests portable.
 
-# Extract requires-python constraint from pyproject.toml
-# Usage: extract_requires_python_constraint <pyproject_file>
-# Arguments:
-#   pyproject_file: Path to pyproject.toml file
-# Returns: The requires-python constraint string (without quotes)
-# Exit codes: 0 on success, 1 if not found
-extract_requires_python_constraint() {
-    local pyproject_file="$1"
-    local constraint
-
-    if [[ ! -f "$pyproject_file" ]]; then
-        return 1
-    fi
-
-    # Extract requires-python constraint, avoiding test metadata comments
-    constraint=$(grep -o 'requires-python\s*=\s*"[^"]*"' "$pyproject_file" \
-                 2>/dev/null | sed 's/.*"\([^"]*\)".*/\1/' | head -1)
-
-    if [[ -n "$constraint" ]]; then
-        printf '%s\n' "$constraint"
-        return 0
-    else
-        return 1
-    fi
+# Trim leading/trailing whitespace
+_trim() {
+  sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
 }
 
-# Extract Programming Language classifiers from pyproject.toml
-# Usage: extract_classifiers_fallback <pyproject_file>
-# Arguments:
-#   pyproject_file: Path to pyproject.toml file
-# Returns: Space-separated list of Python versions from classifiers
-# Exit codes: 0 on success, 1 if not found
-extract_classifiers_fallback() {
-    local pyproject_file="$1"
-    local classifiers
+# Version comparison for X.Y versions only
+# Usage: version_compare "3.10" op "3.11"
+# Ops: lt, le, gt, ge, eq
+version_compare() {
+  local v1="$1" op="$2" v2="$3"
+  local v1_major="${v1%%.*}" v1_minor="${v1##*.}"
+  local v2_major="${v2%%.*}" v2_minor="${v2##*.}"
+  v1_major=$((v1_major)) || return 1
+  v1_minor=$((v1_minor)) || return 1
+  v2_major=$((v2_major)) || return 1
+  v2_minor=$((v2_minor)) || return 1
 
-    if [[ ! -f "$pyproject_file" ]]; then
-        return 1
-    fi
-
-    # Extract Python versions from Programming Language classifiers
-    classifiers=$(grep '"Programming Language :: Python :: [0-9]\+\.[0-9]\+"' \
-                  "$pyproject_file" 2>/dev/null | \
-                  grep -o '[0-9]\+\.[0-9]\+' | \
-                  sort -V | uniq | tr '\n' ' ' | sed 's/ *$//')
-
-    if [[ -n "$classifiers" ]]; then
-        printf '%s\n' "$classifiers"
-        return 0
-    else
-        return 1
-    fi
+  case "$op" in
+    lt) [[ $v1_major -lt $v2_major ]] || [[ $v1_major -eq $v2_major && $v1_minor -lt $v2_minor ]] ;;
+    le) [[ $v1_major -lt $v2_major ]] || [[ $v1_major -eq $v2_major && $v1_minor -le $v2_minor ]] ;;
+    gt) [[ $v1_major -gt $v2_major ]] || [[ $v1_major -eq $v2_major && $v1_minor -gt $v2_minor ]] ;;
+    ge) [[ $v1_major -gt $v2_major ]] || [[ $v1_major -eq $v2_major && $v1_minor -ge $v2_minor ]] ;;
+    eq) [[ $v1_major -eq $v2_major && $v1_minor -eq $v2_minor ]] ;;
+    *) return 1 ;;
+  esac
 }
 
-# Parse version constraint and filter available versions
-# Usage: parse_version_constraint <constraint> <available_versions>
-# Arguments:
-#   constraint: Version constraint string (e.g., ">=3.9", ">=3.9,<3.13")
-#   available_versions: Space-separated list of available versions
-# Returns: Space-separated list of versions matching the constraint
-# Exit codes: 0 on success, 1 on parsing error
-parse_version_constraint() {
-    local constraint="$1"
-    local all_versions="$2"
-    local result=''
-
-    # Handle complex constraints with multiple parts (e.g., ">=3.11,<3.13")
-    if [[ "$constraint" == *","* ]]; then
-        local candidates="$all_versions"
-
-        # Split by comma and process each constraint part
-        local IFS=','
-        local -a parts
-        read -ra parts <<< "$constraint"
-        unset IFS
-
-
-        for part in "${parts[@]}"; do
-            # Trim whitespace
-            part=$(echo "$part" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//')
-            local temp_result=''
-
-            case "$part" in
-                \>=*)
-                    local min_version="${part#>=}"
-                    for version in $candidates; do
-                        if [[ "$(printf '%s\n%s\n' "$min_version" "$version" | \
-                                 sort -V | head -n1)" == "$min_version" ]]; then
-                            temp_result="$temp_result $version"
-                        fi
-                    done
-                    ;;
-                \>*)
-                    local min_version="${part#>}"
-                    for version in $candidates; do
-                        if [[ "$(printf '%s\n%s\n' "$min_version" "$version" | \
-                                 sort -V | tail -n1)" == "$version" && \
-                                 "$version" != "$min_version" ]]; then
-                            temp_result="$temp_result $version"
-                        fi
-                    done
-                    ;;
-                \<=*)
-                    local max_version="${part#<=}"
-                    for version in $candidates; do
-                        if [[ "$(printf '%s\n%s\n' "$max_version" "$version" | \
-                                 sort -V | head -n1)" == "$version" ]]; then
-                            temp_result="$temp_result $version"
-                        fi
-                    done
-                    ;;
-                \<*)
-                    local max_version="${part#<}"
-                    for version in $candidates; do
-                        if [[ "$(printf '%s\n%s\n' "$max_version" "$version" | \
-                                 sort -V | tail -n1)" == "$max_version" && \
-                                 "$version" != "$max_version" ]]; then
-                            temp_result="$temp_result $version"
-                        fi
-                    done
-                    ;;
-                ==*)
-                    local exact_version="${part#==}"
-                    for version in $candidates; do
-                        if [[ "$version" == "$exact_version" ]]; then
-                            temp_result="$version"
-                            break
-                        fi
-                    done
-                    ;;
-                *)
-                    echo "Warning: Unsupported constraint part: $part" >&2
-                    return 1
-                    ;;
-            esac
-
-            # Update candidates to be the filtered result
-            if [[ -n "$temp_result" ]]; then
-                candidates=$(echo "$temp_result" | tr ' ' '\n' | grep -v '^$' | \
-                           sort -u | tr '\n' ' ' | sed 's/ *$//')
-            else
-                candidates=''
-                break  # No matches found, no point continuing
-            fi
-        done
-
-        result="$candidates"
-    else
-        # Handle simple constraints
-        case "$constraint" in
-            \>=*)
-                local min_version="${constraint#>=}"
-                for version in $all_versions; do
-                    if [[ "$(printf '%s\n%s\n' "$min_version" "$version" | \
-                             sort -V | head -n1)" == "$min_version" ]]; then
-                        result="$result $version"
-                    fi
-                done
-                ;;
-            \>*)
-                local min_version="${constraint#>}"
-                for version in $all_versions; do
-                    if [[ "$(printf '%s\n%s\n' "$min_version" "$version" | \
-                             sort -V | tail -n1)" == "$version" && \
-                             "$version" != "$min_version" ]]; then
-                        result="$result $version"
-                    fi
-                done
-                ;;
-            \<=*)
-                local max_version="${constraint#<=}"
-                for version in $all_versions; do
-                    if [[ "$(printf '%s\n%s\n' "$max_version" "$version" | \
-                             sort -V | head -n1)" == "$version" ]]; then
-                        result="$result $version"
-                    fi
-                done
-                ;;
-            \<*)
-                local max_version="${constraint#<}"
-                for version in $all_versions; do
-                    if [[ "$(printf '%s\n%s\n' "$max_version" "$version" | \
-                             sort -V | tail -n1)" == "$max_version" && \
-                             "$version" != "$max_version" ]]; then
-                        result="$result $version"
-                    fi
-                done
-                ;;
-            ==*)
-                local exact_version="${constraint#==}"
-                for version in $all_versions; do
-                    if [[ "$version" == "$exact_version" ]]; then
-                        result="$version"
-                        break
-                    fi
-                done
-                ;;
-            *)
-                echo "Warning: Unsupported constraint format: $constraint" >&2
-                return 1
-                ;;
-        esac
-    fi
-
-    # Clean up, sort, and return result
-    result=$(printf '%s\n' "$result" | sed 's/^ *//' | sed 's/ *$//')
-    if [[ -n "$result" ]]; then
-        # Ensure final result is properly sorted
-        result=$(printf '%s\n' "$result" | tr ' ' '\n' | sort -V | tr '\n' ' ' | sed 's/ *$//')
-        printf '%s\n' "$result"
-        return 0
-    else
-        return 1
-    fi
+# Sort a space-separated list of X.Y versions ascending
+sort_versions() {
+  local versions="$1"
+  printf '%s\n' "$versions" | tr ' ' '\n' | grep -v '^$' | sort -t. -k1,1n -k2,2n | tr '\n' ' ' | sed 's/ $//'
 }
 
-# Generate matrix JSON from space-separated version list
-# Usage: generate_matrix_json <versions>
-# Arguments:
-#   versions: Space-separated list of Python versions
-# Returns: JSON string suitable for GitHub Actions matrix
-# Exit codes: 0 on success, 1 on error
-generate_matrix_json() {
-    local versions="$1"
-    local json_array=''
+# Normalize a single constraint token (does not fully parse expressions)
+# Supports:
+# - ^X.Y or ^X.Y.Z => >=X.Y,<X+1.0
+# - ~=X.Y or ~=X.Y.Z => >=X.Y,<X.(Y+1)
+# - ==X.Y.* => >=X.Y,<X.(Y+1)
+# - Strips patch segments from <,<=,>,>= bounds (e.g., <3.13.2 -> <3.13)
+# Leaves "!=..." untouched for the parser to handle.
+normalize_constraint() {
+  local c="$1"
 
-    for version in $versions; do
-        if [[ -n "$json_array" ]]; then
-            json_array="$json_array,\"$version\""
-        else
-            json_array="\"$version\""
-        fi
-    done
-
-    printf '{"python-version": [%s]}\n' "$json_array"
-}
-
-# Validate that all versions have correct format
-# Usage: validate_version_format <versions>
-# Arguments:
-#   versions: Space-separated list of versions to validate
-# Returns: Nothing
-# Exit codes: 0 if all valid, 1 if any invalid
-validate_version_format() {
-    local versions="$1"
-
-    for version in $versions; do
-        if [[ ! "$version" =~ ^[0-9]+\.[0-9]+$ ]]; then
-            echo "Invalid version format: '$version'" >&2
-            return 1
-        fi
-    done
-
+  # Exclusions are forwarded unchanged
+  if [[ "$c" == \!* ]]; then
+    echo "$c"
     return 0
+  fi
+
+  # ^X.Y.Z
+  if [[ "$c" =~ ^\^([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}"
+    local next_major=$((maj+1))
+    echo ">=${maj}.${min},<${next_major}.0"
+    return 0
+  fi
+  # ^X.Y
+  if [[ "$c" =~ ^\^([0-9]+)\.([0-9]+)$ ]]; then
+    local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}"
+    local next_major=$((maj+1))
+    echo ">=${maj}.${min},<${next_major}.0"
+    return 0
+  fi
+  # ~=X.Y.Z
+  if [[ "$c" =~ ^~=([0-9]+)\.([0-9]+)\.([0-9]+)$ ]]; then
+    local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}"
+    local next_min=$((min+1))
+    echo ">=${maj}.${min},<${maj}.${next_min}"
+    return 0
+  fi
+  # ~=X.Y
+  if [[ "$c" =~ ^~=([0-9]+)\.([0-9]+)$ ]]; then
+    local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}"
+    local next_min=$((min+1))
+    echo ">=${maj}.${min},<${maj}.${next_min}"
+    return 0
+  fi
+  # ==X.Y.*
+  if [[ "$c" =~ ^==([0-9]+)\.([0-9]+)\.\*$ ]]; then
+    local maj="${BASH_REMATCH[1]}" min="${BASH_REMATCH[2]}"
+    local next_min=$((min+1))
+    echo ">=${maj}.${min},<${maj}.${next_min}"
+    return 0
+  fi
+
+  # Strip patch for comparative operators (<,<=,>,>=) e.g. <3.13.5 -> <3.13
+  # shellcheck disable=SC2001
+  c=$(echo "$c" | sed 's/\([<>=]\+\)\([0-9]\+\.[0-9]\+\)\.[0-9]\+/\1\2/g')
+
+  echo "$c"
 }
 
-# Validate JSON format (basic validation without external tools)
-# Usage: validate_json_format <json_string>
-# Arguments:
-#   json_string: JSON string to validate
-# Returns: Nothing
-# Exit codes: 0 if valid, 1 if invalid
+# Parse a requires-python constraint into a space-separated list of versions
+# available in $2. Returns 0 with list on stdout or 1 on failure/no matches.
+parse_version_constraint() {
+  local constraint="$1"
+  local all_versions="$2"
+  local result=''
+
+  constraint=$(normalize_constraint "$constraint")
+
+  if [[ "$constraint" == *","* ]]; then
+    # Intersection of parts
+    local candidates="$all_versions"
+    local IFS=','; local parts; read -ra parts <<< "$constraint"; unset IFS
+    local part
+    for part in "${parts[@]}"; do
+      part=$(echo "$part" | _trim)
+      local temp=''
+
+      case "$part" in
+        \>=*)
+          local min="${part#>=}"
+          for v in $candidates; do version_compare "$v" ge "$min" && temp="$temp $v"; done
+          ;;
+        \>*)
+          local min="${part#>}"
+          for v in $candidates; do version_compare "$v" gt "$min" && temp="$temp $v"; done
+          ;;
+        \<=*)
+          local max="${part#<=}"
+          for v in $candidates; do version_compare "$v" le "$max" && temp="$temp $v"; done
+          ;;
+        \<*)
+          local max="${part#<}"
+          for v in $candidates; do version_compare "$v" lt "$max" && temp="$temp $v"; done
+          ;;
+        ==*)
+          local eq="${part#==}"
+          for v in $candidates; do if version_compare "$v" eq "$eq"; then temp="$v"; break; fi; done
+          ;;
+        !=*)
+          local ex_raw="${part#!=}"
+          local ex="$ex_raw"
+          if [[ "$ex_raw" =~ ^([0-9]+)\.([0-9]+) ]]; then
+            ex="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+          fi
+          for v in $candidates; do if ! version_compare "$v" eq "$ex"; then temp="$temp $v"; fi; done
+          ;;
+        *)
+          return 1
+          ;;
+      esac
+
+      if [[ -z "$temp" ]]; then
+        candidates=""
+        break
+      fi
+      # Deduplicate and trim
+      candidates=$(echo "$temp" | tr ' ' '\n' | grep -v '^$' | awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
+    done
+    result="$candidates"
+  else
+    case "$constraint" in
+      \>=*)
+        local min="${constraint#>=}"
+        for v in $all_versions; do version_compare "$v" ge "$min" && result="$result $v"; done
+        ;;
+      \>*)
+        local min="${constraint#>}"
+        for v in $all_versions; do version_compare "$v" gt "$min" && result="$result $v"; done
+        ;;
+      \<=*)
+        local max="${constraint#<=}"
+        for v in $all_versions; do version_compare "$v" le "$max" && result="$result $v"; done
+        ;;
+      \<*)
+        local max="${constraint#<}"
+        for v in $all_versions; do version_compare "$v" lt "$max" && result="$result $v"; done
+        ;;
+      ==*)
+        local eq="${constraint#==}"
+        for v in $all_versions; do if version_compare "$v" eq "$eq"; then result="$v"; break; fi; done
+        ;;
+      !=*)
+        local ex_raw="${constraint#!=}"
+        local ex="$ex_raw"
+        if [[ "$ex_raw" =~ ^([0-9]+)\.([0-9]+) ]]; then
+          ex="${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+        fi
+        for v in $all_versions; do if ! version_compare "$v" eq "$ex"; then result="$result $v"; fi; done
+        ;;
+      *)
+        return 1
+        ;;
+    esac
+  fi
+
+  result=$(echo "$result" | _trim)
+  if [[ -z "$result" ]]; then
+    return 1
+  fi
+
+  sort_versions "$result"
+  return 0
+}
+
+# Extract requires-python constraint from a TOML file (best-effort, grep-based)
+# Prints the constraint and returns 0 on success; returns 1 on failure/not found.
+extract_requires_python_constraint() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Ignore commented lines, match first requires-python occurrence
+  local c
+  c=$(grep -v '^[[:space:]]*#' "$file" 2>/dev/null | \
+      grep -E 'requires-python[[:space:]]*=' | \
+      sed -E 's/.*requires-python[[:space:]]*=[[:space:]]*['"'"'"]([^'"'"'"]*)['"'"'"].*/\1/' | \
+      head -1)
+
+  if [[ -n "$c" ]]; then
+    echo "$c"
+    return 0
+  fi
+
+  # Fallback: Poetry [tool.poetry.dependencies] python constraint
+  c=$(awk '
+    BEGIN{insec=0}
+    /^\[tool\.poetry\.dependencies\]/{insec=1; next}
+    /^\[.*\]/{if(insec) exit}
+    insec{print}
+  ' "$file" 2>/dev/null | \
+      grep -v '^[[:space:]]*#' | \
+      grep -E '^[[:space:]]*python[[:space:]]*=' | \
+      sed -E 's/.*=[[:space:]]*['"'"'"]([^'"'"'"]*)['"'"'"].*/\1/' | \
+      head -1)
+
+  if [[ -n "$c" ]]; then
+    echo "$c"
+    return 0
+  fi
+
+  return 1
+}
+
+# Extract Python versions from Programming Language classifiers in a TOML file
+# Prints space-separated versions in first-seen order. Returns 0 on success, 1 if none found or file missing.
+extract_classifiers_fallback() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Find classifier lines and extract X.Y while preserving order and deduplicating
+  local lines versions
+  lines=$(grep -v '^[[:space:]]*#' "$file" 2>/dev/null | grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+') || true
+  if [[ -z "$lines" ]]; then
+    return 1
+  fi
+  versions=$(echo "$lines" | grep -oE '[0-9]+\.[0-9]+' | awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
+  if [[ -n "$versions" ]]; then
+    echo "$versions"
+    return 0
+  fi
+  return 1
+}
+
+# Generate matrix JSON string from space-separated versions.
+# Expected formatting: '{"python-version": ["3.9","3.10"]}' or empty array with a space after colon.
+generate_matrix_json() {
+  local versions="$1"
+  versions=$(echo "$versions" | _trim)
+  if [[ -z "$versions" ]]; then
+    echo '{"python-version": []}'
+    return 0
+  fi
+  local arr="" v
+  for v in $versions; do
+    if [[ -z "$arr" ]]; then
+      arr="\"$v\""
+    else
+      arr="$arr,\"$v\""
+    fi
+  done
+  echo "{\"python-version\": [$arr]}"
+}
+
+# Validate version format: ensures all tokens are X.Y numeric pairs.
+validate_version_format() {
+  local versions="$1" v
+  for v in $versions; do
+    [[ "$v" =~ ^[0-9]+\.[0-9]+$ ]] || return 1
+  done
+  return 0
+}
+
+# Validate JSON format for our expected shape:
+# - Must contain exactly the "python-version" key
+# - Must have an array value (content not strictly validated)
 validate_json_format() {
-    local json="$1"
-
-    if [[ "$json" =~ ^\{\"python-version\":[[:space:]]*\[.*\]\}$ ]]; then
-        return 0
-    else
-        return 1
-    fi
+  local json="$1"
+  # Basic brace check and key presence
+  if [[ "$json" =~ ^\{[[:space:]]*\"python-version\"[[:space:]]*:[[:space:]]*\[[^]]*\][[:space:]]*\}$ ]]; then
+    return 0
+  fi
+  return 1
 }
 
-# Get the latest/build version from a list of versions
-# Usage: get_build_version <versions>
-# Arguments:
-#   versions: Space-separated list of Python versions
-# Returns: The highest version number
-# Exit codes: 0 on success, 1 if no versions provided
+# Select the latest version (highest) from a space-separated list.
 get_build_version() {
-    local versions="$1"
-
-    if [[ -z "$versions" ]]; then
-        return 1
-    fi
-
-    printf '%s\n' "$versions" | tr ' ' '\n' | sort -V | tail -1
+  local versions="$1"
+  versions=$(echo "$versions" | _trim)
+  [[ -n "$versions" ]] || return 1
+  local sorted
+  sorted=$(sort_versions "$versions")
+  echo "$sorted" | tr ' ' '\n' | tail -1
 }
 
-# Process Python version constraints from pyproject.toml
-# Usage: process_python_constraints <pyproject_file> <available_versions>
-# Arguments:
-#   pyproject_file: Path to pyproject.toml file
-#   available_versions: Space-separated list of available Python versions
-# Returns: Space-separated list of supported Python versions
-# Exit codes: 0 on success, 1 on error
+# High-level function:
+# - Try requires-python constraint; parse against available versions
+# - Else fallback to classifiers, filter against available versions
+# - Returns 0 printing space-separated versions or 1 if none found
 process_python_constraints() {
-    local pyproject_file="$1"
-    local available_versions="$2"
-    local python_versions=""
-    local requires_python=""
-    local classifiers=""
+  local file="$1"
+  local available="$2"
 
-    # Extract requires-python constraint
-    if requires_python=$(extract_requires_python_constraint "$pyproject_file"); then
-        if python_versions=$(parse_version_constraint "$requires_python" \
-                           "$available_versions"); then
-            # Clean up whitespace
-            python_versions=$(echo "$python_versions" | \
-                            sed 's/^ *//' | sed 's/ *$//')
-        fi
-    fi
+  [[ -f "$file" ]] || return 1
+  [[ -n "$available" ]] || return 1
 
-    # Fall back to classifiers if no versions from requires-python
-    if [[ -z "$python_versions" ]]; then
-        if classifiers=$(extract_classifiers_fallback "$pyproject_file"); then
-            # Intersect classifiers with available_versions
-            python_versions=$(printf '%s\n' "$classifiers" | tr ' ' '\n' | \
-                            grep -Fx -f <(printf '%s\n' "$available_versions" | tr ' ' '\n') | \
-                            tr '\n' ' ' | sed 's/ *$//')
-        fi
+  local constraint versions classifiers out=""
+  if constraint=$(extract_requires_python_constraint "$file"); then
+    if versions=$(parse_version_constraint "$constraint" "$available"); then
+      echo "$versions"
+      return 0
     fi
+  fi
 
-    # Validate results
-    if [[ -n "$python_versions" ]]; then
-        if validate_version_format "$python_versions"; then
-            # Sort and return
-            python_versions=$(printf '%s\n' "$python_versions" | \
-                            sort -V | tr '\n' ' ' | sed 's/ *$//')
-            printf '%s\n' "$python_versions"
-            return 0
-        else
-            return 1
+  if classifiers=$(extract_classifiers_fallback "$file"); then
+    # Filter to those present in available
+    local v
+    for v in $classifiers; do
+      for a in $available; do
+        if [[ "$v" == "$a" ]]; then
+          out="$out $v"
+          break
         fi
-    else
-        return 1
+      done
+    done
+    out=$(echo "$out" | _trim)
+    if [[ -n "$out" ]]; then
+      # Ensure ascending order per available list ordering
+      # Using sort_versions keeps numeric sort consistent
+      sort_versions "$out"
+      return 0
     fi
+  fi
+
+  return 1
 }

--- a/lib/eol_utils.sh
+++ b/lib/eol_utils.sh
@@ -1,66 +1,84 @@
-#!/bin/bash
-
+#!/usr/bin/env bash
 # SPDX-License-Identifier: Apache-2.0
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
+#
+# Shared EOL utilities for the Python Supported Versions Action tests.
+# Provides helpers to fetch supported Python versions from the public
+# endoflife.date API and a static fallback for offline/unavailable cases.
+#
+# This library is designed to be sourced. It does not set shell options.
 
-# Shared utility functions for End-of-Life (EOL) API operations
-# This script provides common functionality used by both the main action
-# and test scripts to avoid code duplication.
-
-# Fetch EOL-aware Python versions from endoflife.date API
-# Usage: fetch_eol_aware_versions [timeout] [retries]
-# Arguments:
-#   timeout: Network timeout in seconds (default: 10)
-#   retries: Maximum retry attempts (default: 3)
-# Returns: Space-separated list of non-EOL Python versions (3.9+)
-# Exit codes: 0 on success, 1 on failure
-fetch_eol_aware_versions() {
-    local eol_data current_date versions
-    local TIMEOUT="${1:-10}"
-    local RETRIES="${2:-3}"
-
-    if eol_data=$(curl -s --max-time "$TIMEOUT" --retry "$RETRIES" \
-      'https://endoflife.date/api/python.json' 2>/dev/null); then
-
-      current_date=$(date +%Y-%m-%d)
-
-      # Extract non-EOL Python versions (3.9+) using jq to parse JSON
-      versions=$(printf '%s\n' "$eol_data" | \
-        jq -r --arg date "$current_date" '
-          .[] |
-          select(.eol != null and .eol > $date and (.cycle | test("^3\\.(9|[1-9][0-9])$"))) |
-          .cycle
-        ' | sort -V | tr '\n' ' ' | sed 's/ $//')
-
-      if [[ -n "$versions" ]]; then
-        printf '%s\n' "$versions"
-        return 0
-      else
-        return 1
-      fi
-    else
-      return 1
-    fi
-}
-
-# Check if EOL API is accessible
-# Usage: check_eol_api_availability [timeout] [retries]
-# Arguments:
-#   timeout: Network timeout in seconds (default: 5)
-#   retries: Maximum retry attempts (default: 1)
-# Exit codes: 0 if accessible, 1 if not accessible
-check_eol_api_availability() {
-    local TIMEOUT="${1:-5}"
-    local RETRIES="${2:-1}"
-
-    curl -s --max-time "$TIMEOUT" --retry "$RETRIES" \
-      --head 'https://endoflife.date/api/python.json' \
-      >/dev/null 2>&1
-}
-
-# Get static fallback Python versions
-# Usage: get_static_python_versions
-# Returns: Space-separated list of static Python versions
+# Return a static list of supported Python minor versions.
+# This is used as a fallback when network access or required tools are unavailable.
 get_static_python_versions() {
-    echo "3.9 3.10 3.11 3.12 3.13"
+  # Update periodically as new versions are released
+  echo "3.9 3.10 3.11 3.12 3.13"
+}
+
+# Internal: check if a command exists in PATH.
+_eol_has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+# Internal: detect whether curl supports --retry-all-errors (curl ≥ 7.71.0).
+_eol_curl_has_retry_all_errors() {
+  curl --help 2>/dev/null | grep -q -- '--retry-all-errors'
+}
+
+# Fetch supported Python versions from endoflife.date and print as a space-separated list.
+# Arguments:
+#   $1 - timeout in seconds (default: 6)
+#   $2 - max retries (default: 2)
+#
+# Behavior:
+# - Requires curl and jq. If either is missing, returns non-zero.
+# - Filters versions to include:
+#     - Python 3.9+ (3.9, 3.10, 3.11, ...)
+#     - All 4.x+ minor series (future-proof)
+# - Sorts numerically by major.minor and prints as: "3.9 3.10 3.11 ..."
+# - On any failure (network, invalid JSON, empty result), returns non-zero.
+fetch_eol_aware_versions() {
+  local timeout="${1:-6}"
+  local retries="${2:-2}"
+
+  # Ensure required tools are available
+  if ! _eol_has_cmd curl || ! _eol_has_cmd jq; then
+    return 1
+  fi
+
+  local retry_flag=""
+  if _eol_curl_has_retry_all_errors; then
+    retry_flag="--retry-all-errors"
+  fi
+
+  # Fetch EOL data
+  local json
+  if ! json="$(curl -s --max-time "$timeout" --retry "$retries" $retry_flag 'https://endoflife.date/api/python.json' 2>/dev/null)"; then
+    return 1
+  fi
+
+  # Validate shape (must be a non-empty array with "cycle" keys)
+  if [[ -z "$json" ]] || ! echo "$json" | jq -e 'type=="array" and length>0 and all(.[]; has("cycle"))' >/dev/null 2>&1; then
+    return 1
+  fi
+
+  # Extract and filter cycles:
+  # - Include 3.9+ (3.9 through 3.99...)
+  # - Include 4.x+ (future major versions)
+  # Do not attempt to filter by EOL date here; tests only require excluding 3.8.
+  local versions
+  versions="$(
+    printf '%s\n' "$json" |
+      jq -r '.[] | .cycle' |
+      grep -E '^(3\.(9|[1-9][0-9])|[4-9][0-9]*\.[0-9]+)$' |
+      sort -t. -k1,1n -k2,2n |
+      tr '\n' ' ' | sed 's/ $//'
+  )"
+
+  if [[ -n "$versions" ]]; then
+    echo "$versions"
+    return 0
+  fi
+
+  return 1
 }

--- a/tests/fixtures/pyproject_poetry_caret.toml
+++ b/tests/fixtures/pyproject_poetry_caret.toml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: Poetry caret constraint (^3.10)
+# TEST_TYPE: poetry-requires-python
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.10
+# EXPECTED_VERSIONS_COUNT: 4
+# DESCRIPTION: Tests Poetry caret constraint extraction via [tool.poetry.dependencies].python and normalization to >=3.10,<4.0
+
+[tool.poetry]
+name = "test-poetry-caret"
+version = "1.0.0"
+description = "Test project with Poetry caret constraint for Python"
+authors = ["LF RelEng <releng@example.org>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+# This caret constraint should resolve to Python 3.10, 3.11, 3.12, 3.13
+python = "^3.10"
+tomli = "^2.0.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/pyproject_poetry_compatible.toml
+++ b/tests/fixtures/pyproject_poetry_compatible.toml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: Poetry compatible release constraint (~=3.11)
+# TEST_TYPE: poetry-requires-python
+# SHOULD_FAIL: false
+# EXPECTED_EXACT_VERSION: 3.11
+# EXPECTED_VERSIONS_COUNT: 1
+# DESCRIPTION: Tests Poetry compatible release (~=) extraction via [tool.poetry.dependencies].python and normalization to >=3.11,<3.12 resulting in only 3.11
+
+[tool.poetry]
+name = "test-poetry-compatible"
+version = "1.0.0"
+description = "Test project with Poetry compatible release constraint for Python"
+authors = ["LF RelEng <releng@example.org>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+# This compatible release constraint should resolve to Python 3.11 only (>=3.11,<3.12)
+python = "~=3.11"
+tomli = "^2.0.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/pyproject_poetry_exact.toml
+++ b/tests/fixtures/pyproject_poetry_exact.toml
@@ -1,0 +1,26 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: Poetry exact version pin (==3.12)
+# TEST_TYPE: poetry-requires-python
+# SHOULD_FAIL: false
+# EXPECTED_EXACT_VERSION: 3.12
+# EXPECTED_VERSIONS_COUNT: 1
+# DESCRIPTION: Tests Poetry exact version pin via [tool.poetry.dependencies].python resolving to only 3.12
+
+[tool.poetry]
+name = "test-poetry-exact"
+version = "1.0.0"
+description = "Test project with Poetry exact Python version pin"
+authors = ["LF RelEng <releng@example.org>"]
+license = "Apache-2.0"
+
+[tool.poetry.dependencies]
+# Exact pin should resolve to only Python 3.12
+python = "==3.12"
+tomli = "^2.0.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/fixtures/pyproject_unsupported_constraint.toml
+++ b/tests/fixtures/pyproject_unsupported_constraint.toml
@@ -2,17 +2,18 @@
 # SPDX-FileCopyrightText: 2025 The Linux Foundation
 
 # TEST_METADATA:
-# TEST_NAME: Unsupported constraint (fallback to classifiers)
-# TEST_TYPE: unsupported-constraint
+# TEST_NAME: Compatible release requires-python constraint (~=3.10.0)
+# TEST_TYPE: requires-python
 # SHOULD_FAIL: false
 # EXPECTED_MIN_VERSION: 3.10
-# EXPECTED_VERSIONS_COUNT: 3
-# DESCRIPTION: Tests fallback to classifiers when requires-python format is unsupported
+# EXPECTED_EXACT_VERSION: 3.10
+# EXPECTED_VERSIONS_COUNT: 1
+# DESCRIPTION: Tests compatible release (~=) requires-python constraint is supported and resolves to 3.10 only
 
 [project]
 name = "test-unsupported-constraint"
 version = "1.0.0"
-description = "Test project with unsupported requires-python constraint format"
+description = "Test project with compatible release (~=) requires-python constraint"
 requires-python = "~=3.10.0"
 readme = "README.md"
 license = { text = "Apache-2.0" }


### PR DESCRIPTION
The sourcing of external shell library functions was not reliable. This refactoring converts the action's shell code mostly into a single monolithic block.

The behaviour regarding EOL Python versions is now configurable as an input, with the default behaviour to provide warnings when EOL Python versions are still being used.