### PR TITLE
CI(testing): Derive expected versions from classifiers

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -106,8 +106,46 @@ jobs:
           # and also requires manual updates whenever the upstream project's
           # classifiers change. Parsing the source of truth keeps the test
           # self-contained and drift-free.
+          pyproject='test-python-project/pyproject.toml'
+          if [ ! -f "$pyproject" ]; then
+            echo "Error: expected file not found: $pyproject"
+            exit 1
+          fi
+
+          # Mirror the action's own parsing behaviour so this test
+          # tracks the action's *final* sorted output:
+          #   * Strip commented lines before matching classifiers, as
+          #     the action does in its classifier fallback path (see
+          #     'extract_classifiers_fallback' in both action.yaml and
+          #     lib/constraint_utils.sh). Without this, a commented-out
+          #     classifier line in pyproject.toml would produce a false
+          #     mismatch.
+          #   * Use the same portable numeric sort the action applies
+          #     via its 'sort_versions' helper (also in action.yaml and
+          #     lib/constraint_utils.sh): 'sort -t. -k1,1n -k2,2n'. This
+          #     avoids relying on GNU-specific 'sort -V' and keeps the
+          #     ordering identical to what the action emits in
+          #     matrix_json.
+          #   * Deduplicate with awk (first-seen wins) instead of
+          #     'sort -u' so the numeric sort order is preserved.
+          #
+          # GitHub Actions runs bash with 'set -eo pipefail' by default,
+          # which would make the assignment below abort the step if
+          # 'grep' finds no matches (exit 1) before our explicit
+          # empty-check can print a user-friendly error. Append
+          # '|| true' to tolerate a no-match exit, then rely on the
+          # explicit '[ -z ... ]' check to diagnose extraction failures
+          # distinctly from genuine action/output disagreements.
           # yamllint disable-line rule:line-length
-          expected_json=$(grep -oE 'Programming Language :: Python :: [0-9]+\.[0-9]+' test-python-project/pyproject.toml | awk -F':: ' '{print $NF}' | sort -V | jq -R . | jq -s -c '{"python-version": .}')
+          classifier_versions=$(grep -v '^[[:space:]]*#' "$pyproject" | grep -oE 'Programming Language :: Python :: [0-9]+\.[0-9]+' | awk -F':: ' '{print $NF}' | sort -t. -k1,1n -k2,2n | awk '!seen[$0]++' || true)
+          if [ -z "$classifier_versions" ]; then
+            echo "Error: no 'Programming Language :: Python :: X.Y' classifiers found in $pyproject"
+            echo "Cannot derive expected python-version list; check the upstream project or the extraction regex."
+            exit 1
+          fi
+
+          # yamllint disable-line rule:line-length
+          expected_json=$(printf '%s\n' "$classifier_versions" | jq -R . | jq -s -c '{"python-version": .}')
           echo "Expected (derived from classifiers): '$expected_json'"
           if [ "$expected_json" != "$actual_json" ]; then
             echo "Error: matrix_json mismatch for test-python-project"

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -99,11 +99,16 @@ jobs:
             exit 1
           fi
 
-          # For test-python-project, validate against the expected Python versions.
-          # The expected versions are stored in the EXPECTED_VERSION_JSON GitHub variable
-          # to avoid hardcoding and allow easy updates when upstream project support changes.
+          # For test-python-project, derive expected Python versions directly
+          # from the classifiers in the checked-out pyproject.toml. This avoids
+          # reliance on the repository-level EXPECTED_VERSION_JSON variable,
+          # which is not reliably populated for pull_request events from forks
+          # and also requires manual updates whenever the upstream project's
+          # classifiers change. Parsing the source of truth keeps the test
+          # self-contained and drift-free.
           # yamllint disable-line rule:line-length
-          expected_json='${{ vars.EXPECTED_VERSION_JSON }}'
+          expected_json=$(grep -oE 'Programming Language :: Python :: [0-9]+\.[0-9]+' test-python-project/pyproject.toml | awk -F':: ' '{print $NF}' | sort -V | jq -R . | jq -s -c '{"python-version": .}')
+          echo "Expected (derived from classifiers): '$expected_json'"
           if [ "$expected_json" != "$actual_json" ]; then
             echo "Error: matrix_json mismatch for test-python-project"
             echo "Expected: $expected_json"


### PR DESCRIPTION
## Summary

The **Test External Repository** job in `testing.yaml` periodically fails with output like:

```
Expected:
Actual:   {"python-version":["3.11","3.12","3.13","3.14"]}
```

### Root cause

The job compares the action's output against `${{ vars.EXPECTED_VERSION_JSON }}`,
a repository-level GitHub Actions variable. That variable is **not reliably
exposed** to workflow runs triggered by `pull_request` events originating from
**forks** of the repo — depending on the repository's fork-PR approval settings,
`vars` can come through as an empty string, while secrets are always blocked.

- Runs from same-repo branches (e.g. `push` to `main`, PRs from branches in
  `lfreleng-actions/python-supported-versions-action`) receive the variable
  fine → test passes.
- Runs from forked PR branches (e.g. the failing run on
  `modeseven-lfreleng-actions:fix/test-python-project-dynamic-version`) see
  an empty `$expected_json` → test fails with the observed mismatch.

The variable is correctly configured with
`{"python-version":["3.11","3.12","3.13","3.14"]}`; that is not the problem.

A secondary issue with the previous design is **drift**: when upstream
`test-python-project`'s classifiers change (e.g. adding 3.14), the repo
variable has to be updated manually in repository settings before the
test can pass again.

### Fix

Derive the expected `python-version` list directly from the classifiers in
the checked-out `test-python-project/pyproject.toml` — the actual source of
truth the action itself reads. This:

- eliminates the dependency on `vars.EXPECTED_VERSION_JSON`, so fork PRs
  run identically to same-repo runs
- auto-tracks upstream changes without manual variable updates
- still fails loudly if the action's parsing disagrees with the classifiers
  (which is the real thing this test should be catching)

### Change

Replace the single line sourcing `vars.EXPECTED_VERSION_JSON` with a small
pipeline that extracts `Programming Language :: Python :: X.Y` classifiers
from the checked-out `pyproject.toml` and assembles them into the expected
JSON shape using `jq`.

The `EXPECTED_VERSION_JSON` repository variable can be removed after merge.