### PR TITLE
Feat: Support legacy projects and EOL fallback

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -156,34 +156,65 @@ jobs:
 
           echo "External repository test passed ✅"
 
-  ### Test Missing pyproject.toml ###
+  ### Test Missing project metadata files (fallback behaviour) ###
   test-missing-pyproject:
-    name: 'Test Missing pyproject.toml'
+    name: 'Test Missing project metadata files'
     runs-on: ubuntu-latest
     permissions:
       contents: read
     timeout-minutes: 8
     steps:
       - name: 'Checkout repository'
+        # yamllint disable-line rule:line-length
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: 'Create empty test directory'
         run: mkdir -p empty-test-dir
 
-      - name: 'Test missing pyproject.toml'
+      - name: 'Run action against empty directory'
         id: test-missing
         uses: ./
         with:
           path_prefix: 'empty-test-dir/'
-        continue-on-error: true
 
-      - name: 'Validate missing pyproject.toml failure'
+      - name: 'Validate fallback outputs'
+        env:
+          OUTCOME: ${{ steps.test-missing.outcome }}
+          VERSIONS_SOURCE: ${{ steps.test-missing.outputs.versions_source }}
+          BUILD_PYTHON: ${{ steps.test-missing.outputs.build_python }}
+          MATRIX_JSON: ${{ steps.test-missing.outputs.matrix_json }}
         run: |
-          if [ "${{ steps.test-missing.outcome }}" != "failure" ]; then
-            echo "Error: Expected test to fail due to missing pyproject.toml"
+          set -euo pipefail
+          if [ "$OUTCOME" != "success" ]; then
+            echo "::error::Action step did not succeed (outcome=$OUTCOME)"
             exit 1
           fi
-          echo "Test correctly failed due to missing pyproject.toml"
+          case "$VERSIONS_SOURCE" in
+            eol-fallback|static-fallback) ;;
+            *)
+              echo "::error::Unexpected versions_source: '$VERSIONS_SOURCE' (expected eol-fallback or static-fallback)"
+              exit 1
+              ;;
+          esac
+          if ! printf '%s' "$BUILD_PYTHON" | grep -Eq '^[0-9]+\.[0-9]+$'; then
+            echo "::error::build_python is empty or malformed: '$BUILD_PYTHON'"
+            exit 1
+          fi
+          if [ -z "$MATRIX_JSON" ]; then
+            echo "::error::matrix_json is empty"
+            exit 1
+          fi
+          # Must parse as JSON, must have a non-empty python-version array.
+          versions_count=$(printf '%s' "$MATRIX_JSON" | jq -r '."python-version" | length')
+          if [ -z "$versions_count" ] || [ "$versions_count" -lt 1 ]; then
+            echo "::error::matrix_json has empty or missing python-version array: '$MATRIX_JSON'"
+            exit 1
+          fi
+          echo "Fallback behaviour validated ✅"
+          echo "  outcome=$OUTCOME"
+          echo "  versions_source=$VERSIONS_SOURCE"
+          echo "  build_python=$BUILD_PYTHON"
+          echo "  matrix_json=$MATRIX_JSON"
 
   ### Test Poetry Fixtures ###
   test-poetry-fixtures:

--- a/README.md
+++ b/README.md
@@ -5,13 +5,26 @@
 
 # 🐍 Extract Python Versions Supported by Project
 
-Parses pyproject.toml and extracts the Python versions supported by the
-project. Determines the most recent version supported and provides JSON
-representing all supported versions, for use in GitHub matrix jobs.
+Parses Python project metadata (`pyproject.toml`, `setup.cfg`, or `setup.py`)
+and extracts the Python versions supported by the project. Determines the
+most recent version supported and provides JSON representing all supported
+versions, for use in GitHub matrix jobs.
 
 **Primary Method**: Extracts from `requires-python` constraint
 (e.g. `requires-python = ">=3.10"`)
 **Fallback Method**: Parses `Programming Language :: Python ::` classifiers
+
+**Source priority** (first match wins):
+
+1. `pyproject.toml` — `requires-python` / Poetry `python` / classifiers
+2. `setup.cfg` — `python_requires` (under `[metadata]` or `[options]`) /
+   classifiers
+3. `setup.py` — `python_requires=` kwarg / classifiers
+4. **EOL-aware fallback** — if no project-side constraint exists
+   anywhere, the action emits a warning and uses the EOL-aware Python
+   versions list (or its static fallback if the network is unavailable).
+   This ensures the action always succeeds with a usable matrix, even on
+   legacy projects that have not yet declared their support window.
 
 This brings alignment with actions/setup-python behavior while maintaining
 compatibility with projects that use explicit version classifiers.
@@ -43,13 +56,14 @@ of your Github workflow:
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name   | Description                                           | Required | Default |
-| --------------- | ----------------------------------------------------- | -------- | ------- |
-| path_prefix     | Directory location containing project code            | false    | '.'     |
-| network_timeout | Network timeout in seconds for API calls              | false    | '6'     |
-| max_retries     | Number of retry attempts for API calls                | false    | '2'     |
-| eol_behaviour   | How to handle EOL Python versions: warn\|strip\|fail  | false    | 'warn'  |
-| offline_mode    | Disable network lookups and use internal version list | false    | 'false' |
+| Variable Name          | Description                                                                                              | Required | Default |
+| ---------------------- | -------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| path_prefix            | Directory location containing project code                                                               | false    | '.'     |
+| network_timeout        | Network timeout in seconds for API calls                                                                 | false    | '6'     |
+| max_retries            | Number of retry attempts for API calls                                                                   | false    | '2'     |
+| eol_behaviour          | How to handle EOL Python versions: warn\|strip\|fail                                                     | false    | 'warn'  |
+| offline_mode           | Disable network lookups and use internal version list                                                    | false    | 'false' |
+| default_python_version | Override `build_python` (X.Y) in fallback mode (`versions_source` = `eol-fallback` or `static-fallback`) | false    | ''      |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -123,13 +137,76 @@ Error: Python 3.8 became unsupported/EOL on date: 2024-10-07 🛑
 
 <!-- markdownlint-disable MD013 -->
 
-| Variable Name      | Description                                             |
-| ------------------ | ------------------------------------------------------- |
-| build_python       | Most recent Python version supported by project         |
-| matrix_json        | All Python versions supported by project as JSON string |
-| supported_versions | Space-separated list of all supported Python versions   |
+| Variable Name      | Description                                                  |
+| ------------------ | ------------------------------------------------------------ |
+| build_python       | Most recent Python version supported by project              |
+| matrix_json        | All Python versions supported by project as JSON string      |
+| supported_versions | Space-separated list of all supported Python versions        |
+| versions_source    | Where the version data came from (see values below)          |
 
 <!-- markdownlint-enable MD013 -->
+
+### `versions_source` values
+
+<!-- markdownlint-disable MD013 MD060 -->
+
+| Value                   | Meaning                                                                                                                     |
+| ----------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `requires-python`       | Parsed from `pyproject.toml` `requires-python` (or Poetry).                                                                 |
+| `classifiers`           | Parsed from `pyproject.toml` Programming Language classifiers.                                                              |
+| `setup-cfg-requires`    | Parsed from `setup.cfg` `python_requires` (under `[metadata]` or `[options]`; also accepts pbr's `python-requires`).        |
+| `setup-cfg-classifiers` | Parsed from `setup.cfg` `[metadata] classifiers`.                                                                           |
+| `setup-py-requires`     | Parsed from `setup.py` `python_requires=` kwarg.                                                                            |
+| `setup-py-classifiers`  | Parsed from `setup.py` Programming Language classifiers.                                                                    |
+| `eol-fallback`          | No constraint declared anywhere; using the live EOL-aware list.                                                             |
+| `static-fallback`       | No constraint declared anywhere; using the static internal list because the EOL API was unavailable or `offline_mode=true`. |
+
+<!-- markdownlint-enable MD013 MD060 -->
+
+Callers should treat `versions_source=eol-fallback` (or `static-fallback`)
+as a soft warning: it indicates the project hasn't declared a Python support
+window. Add `requires-python` (or `python_requires` in `setup.cfg` /
+`setup.py`) to silence the warning.
+
+## Legacy project support (`setup.cfg` / `setup.py`)
+
+The action also reads metadata from legacy projects that have not yet
+adopted `pyproject.toml`. The lookup order is:
+
+1. `pyproject.toml` — `requires-python` first, then Poetry's
+   `[tool.poetry.dependencies] python = "..."`, then classifiers.
+2. `setup.cfg` — `python_requires = ...` under either `[metadata]` or
+   `[options]` (also accepts the hyphenated `python-requires` variant
+   used by pbr under `[metadata]`), then `[metadata] classifiers`.
+3. `setup.py` — best-effort regex over `python_requires="..."` (single
+   or double quotes), then over Programming Language classifiers.
+
+If none of the three declare a Python version window, the action falls
+back to the EOL-aware list (or the static internal list when the
+endoflife.date API is unavailable), emits a `::warning::`, and **still
+produces a usable `build_python` and `matrix_json`** so callers do not
+have to special-case legacy projects. The `versions_source` output lets
+callers detect this case and decide policy.
+
+### Overriding `build_python` on fallback
+
+When the action is in fallback mode (`versions_source` =
+`eol-fallback` *or* `static-fallback` — the latter covers EOL API
+unavailability and `offline_mode=true`), you can pin `build_python`
+to a specific X.Y version. The override applies when the requested
+version appears in the emitted matrix; otherwise the action keeps
+the computed `build_python` and logs a warning. The matrix itself
+remains unchanged by this input.
+
+```yaml
+- name: "Get Python versions"
+  uses: lfreleng-actions/python-supported-versions-action@main
+  with:
+    default_python_version: '3.12'
+```
+
+This is useful for org-wide policy where every legacy project should
+build against the same baseline Python until it declares its own.
 
 ## Workflow Output Example
 

--- a/action.yaml
+++ b/action.yaml
@@ -36,6 +36,16 @@ inputs:
     description: "Disable network lookups and use internal version list only"
     required: false
     default: 'false'
+  default_python_version:
+    description: >-
+      Override build_python (X.Y) when the action is in fallback mode
+      (versions_source=eol-fallback or static-fallback, e.g. no
+      project-side constraint declared, EOL API unreachable, or
+      offline_mode=true). The override is ignored unless it is part of
+      the emitted matrix; out-of-matrix values keep the computed
+      build_python and emit a warning.
+    required: false
+    default: ''
 
 outputs:
   build_python:
@@ -48,6 +58,12 @@ outputs:
   supported_versions:
     description: "Space-separated list of all supported Python versions"
     value: "${{ steps.versions.outputs.supported_versions }}"
+  versions_source:
+    description: >-
+      Source of the version data: requires-python, classifiers,
+      setup-cfg-requires, setup-cfg-classifiers, setup-py-requires,
+      setup-py-classifiers, eol-fallback, or static-fallback
+    value: "${{ steps.versions.outputs.versions_source }}"
 
 runs:
   using: "composite"
@@ -61,6 +77,7 @@ runs:
         INPUT_MAX_RETRIES: ${{ inputs.max_retries }}
         INPUT_EOL_BEHAVIOUR: ${{ inputs.eol_behaviour }}
         INPUT_OFFLINE_MODE: ${{ inputs.offline_mode }}
+        INPUT_DEFAULT_PYTHON_VERSION: ${{ inputs.default_python_version }}
       # yamllint disable rule:line-length
       run: |
         # Process and determine supported Python versions
@@ -70,6 +87,7 @@ runs:
         RETRIES="${INPUT_MAX_RETRIES}"
         EOL_BEHAVIOUR="${INPUT_EOL_BEHAVIOUR}"
         OFFLINE_MODE="${INPUT_OFFLINE_MODE}"
+        DEFAULT_PYTHON_VERSION="${INPUT_DEFAULT_PYTHON_VERSION:-}"
 
 
         # Internal list of supported Python versions (requires periodic update)
@@ -97,16 +115,21 @@ runs:
         fi
 
 
-        # Validate directory and pyproject.toml existence
+        # Validate directory existence (project metadata files are optional;
+        # legacy projects may rely on setup.cfg or setup.py, or none at all).
         if [[ ! -d "$path_prefix" ]]; then
           echo 'Error: invalid path/prefix to project directory ❌'
           exit 1
         fi
 
-        if [[ ! -f "$path_prefix/pyproject.toml" ]]; then
-          echo 'Error: missing pyproject.toml file ❌'
-          exit 1
-        fi
+        # Track which metadata files are present for downstream logic.
+        HAS_PYPROJECT='false'
+        HAS_SETUP_CFG='false'
+        HAS_SETUP_PY='false'
+        [[ -f "$path_prefix/pyproject.toml" ]] && HAS_PYPROJECT='true'
+        [[ -f "$path_prefix/setup.cfg" ]] && HAS_SETUP_CFG='true'
+        [[ -f "$path_prefix/setup.py" ]] && HAS_SETUP_PY='true'
+        echo "Metadata files: pyproject=$HAS_PYPROJECT setup.cfg=$HAS_SETUP_CFG setup.py=$HAS_SETUP_PY"
 
         # Validate eol_behaviour input
         if [[ "$EOL_BEHAVIOUR" != "warn" && "$EOL_BEHAVIOUR" != "strip" && \
@@ -724,68 +747,94 @@ runs:
 
         ### Main execution starts here ###
 
-        # Get supported Python versions
+        # Source shared library helpers AFTER all inline function definitions.
+        # This ensures the library's unit-tested implementations override the
+        # inline duplicates (parse_version_constraint, sort_versions, ...) so
+        # the layered processor and the inline call sites both go through the
+        # same code path.
+        # shellcheck disable=SC1091
+        if [[ -n "${GITHUB_ACTION_PATH:-}" && \
+              -f "$GITHUB_ACTION_PATH/lib/constraint_utils.sh" ]]; then
+          source "$GITHUB_ACTION_PATH/lib/constraint_utils.sh"
+        fi
+
+        # Get supported Python versions and remember whether we got them from
+        # the live API (eol-fallback) or the internal static list (static-fallback).
+        VERSIONS_SOURCE_FALLBACK="eol-fallback"
         if SUPPORTED_VERSIONS=$(fetch_python_data "$TIMEOUT" "$RETRIES" "versions"); then
           if [[ "$OFFLINE_MODE" == "true" ]]; then
               echo "Using internal supported Python versions (offline mode) 📴"
+              VERSIONS_SOURCE_FALLBACK="static-fallback"
           else
               echo "Retrieved supported Python versions from API service 🌍"
           fi
         else
           echo "Unable to retrieve supported Python versions, using internal list ⚠️"
           SUPPORTED_VERSIONS="$INTERNAL_SUPPORTED_VERSIONS"
+          VERSIONS_SOURCE_FALLBACK="static-fallback"
         fi
         echo "Supported versions: $SUPPORTED_VERSIONS"
 
-        # Extract requires-python constraint
-        REQUIRES_PYTHON=""
-        if command -v python3 >/dev/null 2>&1; then
-            if REQUIRES_PYTHON=$(extract_requires_python_python "$PYPROJECT_FILE"); then
-              echo "Found requires-python constraint (via Python): $REQUIRES_PYTHON"
-            fi
-        fi
-
-        # Fall back to grep/sed parsing if Python parsing failed
-        if [[ -z "$REQUIRES_PYTHON" ]]; then
-            if REQUIRES_PYTHON=$(extract_requires_python_fallback "$PYPROJECT_FILE"); then
-              echo "Found requires-python constraint (via fallback): $REQUIRES_PYTHON"
-            fi
-        fi
-
-        # Extract classifiers fallback
-        CLASSIFIERS=""
-        if CLASSIFIERS=$(extract_classifiers_fallback "$PYPROJECT_FILE"); then
-          echo "Programming Language classifiers: $CLASSIFIERS"
-        fi
-
-        # Check if any constraints were found
-        if [[ -z "$REQUIRES_PYTHON" && -z "$CLASSIFIERS" ]]; then
-          echo "Error: No Python version constraints found in $PYPROJECT_FILE ❌"
-          exit 1
-        fi
-
-        # Process constraints and determine requested versions
+        # Try the layered project-side extraction (pyproject.toml → setup.cfg
+        # → setup.py) via the shared library. If the library is not available
+        # for some reason, fall back to the legacy pyproject-only path.
         REQUESTED_PYTHON_VERSIONS=""
+        VERSIONS_SOURCE=""
 
-        # Try requires-python first
-        if [[ -n "$REQUIRES_PYTHON" ]]; then
+        if declare -F process_python_constraints_layered >/dev/null 2>&1; then
+          LAYERED_OUT=""
+          if LAYERED_OUT=$(process_python_constraints_layered "$path_prefix" "$SUPPORTED_VERSIONS"); then
+            REQUESTED_PYTHON_VERSIONS=$(printf '%s\n' "$LAYERED_OUT" | sed -n '1p')
+            VERSIONS_SOURCE=$(printf '%s\n' "$LAYERED_OUT" | sed -n '2p')
+            echo "🔍 Found Python version data via: $VERSIONS_SOURCE"
+          fi
+        elif [[ -f "$PYPROJECT_FILE" ]]; then
+          # Legacy inline path: pyproject-only.
+          REQUIRES_PYTHON=""
+          if command -v python3 >/dev/null 2>&1; then
+            REQUIRES_PYTHON=$(extract_requires_python_python "$PYPROJECT_FILE" || true)
+          fi
+          if [[ -z "$REQUIRES_PYTHON" ]]; then
+            REQUIRES_PYTHON=$(extract_requires_python_fallback "$PYPROJECT_FILE" || true)
+          fi
+          CLASSIFIERS=$(extract_classifiers_fallback "$PYPROJECT_FILE" || true)
+          if [[ -n "$REQUIRES_PYTHON" ]]; then
             if REQUESTED_PYTHON_VERSIONS=$(parse_version_constraint "$REQUIRES_PYTHON" "$SUPPORTED_VERSIONS"); then
-                echo "🔍 Processed requires-python constraint successfully"
-                # Clean up whitespace
-                REQUESTED_PYTHON_VERSIONS=$(echo "$REQUESTED_PYTHON_VERSIONS" | sed 's/^ *//' | sed 's/ *$//')
+              VERSIONS_SOURCE="requires-python"
             fi
+          fi
+          if [[ -z "$REQUESTED_PYTHON_VERSIONS" && -n "$CLASSIFIERS" ]]; then
+            # Filter classifier-derived versions to those present in the
+            # supported list, mirroring _filter_to_available in the shared
+            # library so both code paths emit consistent matrices.
+            FILTERED_CLASSIFIERS=""
+            for v in $CLASSIFIERS; do
+              for a in $SUPPORTED_VERSIONS; do
+                if [[ "$v" == "$a" ]]; then
+                  FILTERED_CLASSIFIERS="$FILTERED_CLASSIFIERS $v"
+                  break
+                fi
+              done
+            done
+            FILTERED_CLASSIFIERS=$(echo "$FILTERED_CLASSIFIERS" | sed 's/^ *//; s/ *$//')
+            if [[ -n "$FILTERED_CLASSIFIERS" ]]; then
+              REQUESTED_PYTHON_VERSIONS="$FILTERED_CLASSIFIERS"
+              VERSIONS_SOURCE="classifiers"
+            fi
+          fi
         fi
 
-        # Fall back to classifiers if no versions from requires-python
-        if [[ -z "$REQUESTED_PYTHON_VERSIONS" && -n "$CLASSIFIERS" ]]; then
-            REQUESTED_PYTHON_VERSIONS="$CLASSIFIERS"
-            echo "Using Programming Language classifiers fallback ⏪"
-        fi
-
-        # Validate results
+        # If nothing was found, fall back to the EOL-aware (or static)
+        # supported-versions list and emit a warning. Do NOT exit non-zero —
+        # legacy projects with no declared constraint are expected. Note: this
+        # branch also covers the case where a constraint *was* declared but
+        # produced zero matches against SUPPORTED_VERSIONS (for example
+        # `requires-python = ">=4.0"` against a 3.x-only available list);
+        # the warning text is therefore phrased to cover both cases.
         if [[ -z "$REQUESTED_PYTHON_VERSIONS" ]]; then
-            echo "Error: Failed to determine Python versions from constraints ❌"
-            exit 1
+          echo "::warning::No usable Python version constraint could be determined from pyproject.toml, setup.cfg or setup.py (none declared, or the declared constraint matched no supported versions) — falling back to the EOL-aware supported-versions list. Add 'requires-python' (or 'python_requires') to silence this warning."
+          REQUESTED_PYTHON_VERSIONS="$SUPPORTED_VERSIONS"
+          VERSIONS_SOURCE="$VERSIONS_SOURCE_FALLBACK"
         fi
 
         if ! validate_version_format "$REQUESTED_PYTHON_VERSIONS"; then
@@ -795,6 +844,7 @@ runs:
         fi
 
         echo "Python versions from constraints: $REQUESTED_PYTHON_VERSIONS"
+        echo "Versions source: $VERSIONS_SOURCE"
 
         # Handle EOL versions based on eol_behaviour setting
         FINAL_PYTHON_VERSIONS=$(handle_eol_versions "$REQUESTED_PYTHON_VERSIONS" "$EOL_BEHAVIOUR" "$TIMEOUT" "$RETRIES")
@@ -816,6 +866,34 @@ runs:
           exit 1
         fi
 
+        # When falling back to the EOL-aware list and the caller has supplied
+        # a default_python_version, override build_python with it (still emit
+        # the full fallback matrix). Useful for org-wide policy.
+        if [[ -n "$DEFAULT_PYTHON_VERSION" && \
+              ( "$VERSIONS_SOURCE" == "eol-fallback" || \
+                "$VERSIONS_SOURCE" == "static-fallback" ) ]]; then
+          if [[ ! "$DEFAULT_PYTHON_VERSION" =~ ^[0-9]+\.[0-9]+$ ]]; then
+            echo "::warning::Ignoring default_python_version='$DEFAULT_PYTHON_VERSION' (must be in X.Y form)"
+          else
+            # Only override when the requested version is actually present in
+            # the final matrix, so downstream steps that consume build_python
+            # are guaranteed to find it in matrix_json.
+            override_ok='false'
+            for _v in $FINAL_PYTHON_VERSIONS; do
+              if [[ "$_v" == "$DEFAULT_PYTHON_VERSION" ]]; then
+                override_ok='true'
+                break
+              fi
+            done
+            if [[ "$override_ok" == 'true' ]]; then
+              echo "Overriding build_python with default_python_version=$DEFAULT_PYTHON_VERSION (fallback in effect)"
+              BUILD_PYTHON="$DEFAULT_PYTHON_VERSION"
+            else
+              echo "::warning::default_python_version='$DEFAULT_PYTHON_VERSION' is not in the supported matrix [$FINAL_PYTHON_VERSIONS]; keeping computed build_python=$BUILD_PYTHON"
+            fi
+          fi
+        fi
+
         if MATRIX_JSON=$(generate_matrix_json "$FINAL_PYTHON_VERSIONS") && \
           validate_json_format "$MATRIX_JSON"; then
           echo "Matrix JSON generated successfully"
@@ -832,6 +910,7 @@ runs:
           echo "__PY_MATRIX_JSON__"
         } >> "$GITHUB_OUTPUT"
         echo "supported_versions=$FINAL_PYTHON_VERSIONS" >> "$GITHUB_OUTPUT"
+        echo "versions_source=$VERSIONS_SOURCE" >> "$GITHUB_OUTPUT"
 
         # Final clean output
         echo "✅ Build Python: $BUILD_PYTHON"

--- a/lib/constraint_utils.sh
+++ b/lib/constraint_utils.sh
@@ -312,6 +312,223 @@ get_build_version() {
   echo "$sorted" | tr ' ' '\n' | tail -1
 }
 
+# Extract python_requires (or python-requires) from setup.cfg.
+# Setuptools' declarative config places `python_requires` under [options];
+# pbr / older projects use `python-requires` under [metadata]. Accept either.
+# Returns 0 with the constraint on stdout, 1 if not found.
+extract_setup_cfg_requires_python() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Pull lines from the [metadata] AND [options] sections, then find
+  # python_requires / python-requires.
+  local raw
+  raw=$(awk '
+    BEGIN{insec=0}
+    /^[[:space:]]*\[(metadata|options)\][[:space:]]*$/{insec=1; next}
+    /^[[:space:]]*\[[^]]+\][[:space:]]*$/{if(insec) insec=0}
+    insec{print}
+  ' "$file" 2>/dev/null | \
+      grep -v '^[[:space:]]*#' | \
+      grep -E '^[[:space:]]*python[_-]requires[[:space:]]*=' | \
+      head -1)
+
+  [[ -n "$raw" ]] || return 1
+
+  # Strip the "key =" prefix, then any wrapping quotes and trailing inline comment / whitespace.
+  local c
+  c=$(printf '%s\n' "$raw" | sed -E 's/^[[:space:]]*python[_-]requires[[:space:]]*=[[:space:]]*//')
+  # Remove trailing inline comment.
+  c=$(printf '%s\n' "$c" | sed -E 's/[[:space:]]+#.*$//')
+  # Strip surrounding single or double quotes if present.
+  c=$(printf '%s\n' "$c" | sed -E "s/^[\"']//; s/[\"']$//")
+  # Trim trailing whitespace.
+  c=$(printf '%s\n' "$c" | sed -E 's/[[:space:]]+$//')
+
+  if [[ -n "$c" ]]; then
+    echo "$c"
+    return 0
+  fi
+  return 1
+}
+
+# Extract Python versions from a setup.cfg [metadata] classifiers (or classifier) block.
+# setup.cfg uses indentation for multi-line list values. Prints space-separated
+# versions in first-seen order, returns 0 if any found.
+extract_setup_cfg_classifiers() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Collect the classifier(s) block: a key line `classifier(s) =` followed by
+  # indented continuation lines. A non-indented line ends the block.
+  local block
+  block=$(awk '
+    BEGIN{insec=0; incls=0}
+    /^[[:space:]]*\[metadata\][[:space:]]*$/{insec=1; next}
+    /^[[:space:]]*\[[^]]+\][[:space:]]*$/{if(insec){insec=0; incls=0}}
+    insec{
+      if (incls) {
+        if ($0 ~ /^[[:space:]]/) { print; next }
+        else { incls=0 }
+      }
+      if ($0 ~ /^[[:space:]]*classifiers?[[:space:]]*=/) {
+        sub(/^[^=]*=/, "", $0); print; incls=1
+      }
+    }
+  ' "$file" 2>/dev/null) || true
+
+  [[ -n "$block" ]] || return 1
+
+  local versions
+  versions=$(printf '%s\n' "$block" | \
+    grep -v '^[[:space:]]*#' | \
+    grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+' | \
+    grep -oE '[0-9]+\.[0-9]+' | \
+    awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
+
+  if [[ -n "$versions" ]]; then
+    echo "$versions"
+    return 0
+  fi
+  return 1
+}
+
+# Best-effort regex extraction of python_requires=... from setup.py.
+extract_setup_py_requires_python() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  local c
+  # Match python_requires="..." or python_requires='...'; ignore commented lines.
+  c=$(grep -v '^[[:space:]]*#' "$file" 2>/dev/null | \
+      grep -oE "python_requires[[:space:]]*=[[:space:]]*['\"][^'\"]+['\"]" | \
+      head -1 | \
+      sed -E "s/python_requires[[:space:]]*=[[:space:]]*['\"]([^'\"]+)['\"]/\1/")
+
+  if [[ -n "$c" ]]; then
+    echo "$c"
+    return 0
+  fi
+  return 1
+}
+
+# Best-effort regex extraction of Programming Language :: Python :: X.Y from setup.py.
+extract_setup_py_classifiers() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  local versions
+  versions=$(grep -v '^[[:space:]]*#' "$file" 2>/dev/null | \
+    grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+' | \
+    grep -oE '[0-9]+\.[0-9]+' | \
+    awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ $//')
+
+  if [[ -n "$versions" ]]; then
+    echo "$versions"
+    return 0
+  fi
+  return 1
+}
+
+# Filter a space-separated list of X.Y versions to those present in available.
+_filter_to_available() {
+  local candidates="$1" available="$2" out="" v a
+  for v in $candidates; do
+    for a in $available; do
+      if [[ "$v" == "$a" ]]; then
+        out="$out $v"
+        break
+      fi
+    done
+  done
+  out=$(echo "$out" | _trim)
+  [[ -n "$out" ]] || return 1
+  sort_versions "$out"
+}
+
+# Layered constraint processing across pyproject.toml, setup.cfg, setup.py.
+# Usage: process_python_constraints_layered <path_prefix> <available_versions>
+# On success, prints two lines:
+#   <space-separated versions>
+#   <source token>
+# Source tokens:
+#   requires-python | classifiers |
+#   setup-cfg-requires | setup-cfg-classifiers |
+#   setup-py-requires | setup-py-classifiers
+# Returns 0 on success, 1 if no usable constraint was produced — either no
+# project-side metadata was found at all, or every constraint/classifier
+# block that was found yielded zero matches once filtered against
+# `available_versions` (e.g. `requires-python = ">=4.0"` against a 3.x-only
+# available list).
+process_python_constraints_layered() {
+  local prefix="$1"
+  local available="$2"
+  prefix="${prefix%/}"
+  [[ -n "$available" ]] || return 1
+
+  local pyproject="$prefix/pyproject.toml"
+  local setup_cfg="$prefix/setup.cfg"
+  local setup_py="$prefix/setup.py"
+
+  local constraint versions classifiers
+
+  # 1) pyproject.toml requires-python / poetry, then classifiers
+  if [[ -f "$pyproject" ]]; then
+    if constraint=$(extract_requires_python_constraint "$pyproject"); then
+      if versions=$(parse_version_constraint "$constraint" "$available"); then
+        echo "$versions"
+        echo "requires-python"
+        return 0
+      fi
+    fi
+    if classifiers=$(extract_classifiers_fallback "$pyproject"); then
+      if versions=$(_filter_to_available "$classifiers" "$available"); then
+        echo "$versions"
+        echo "classifiers"
+        return 0
+      fi
+    fi
+  fi
+
+  # 2) setup.cfg python_requires / classifiers
+  if [[ -f "$setup_cfg" ]]; then
+    if constraint=$(extract_setup_cfg_requires_python "$setup_cfg"); then
+      if versions=$(parse_version_constraint "$constraint" "$available"); then
+        echo "$versions"
+        echo "setup-cfg-requires"
+        return 0
+      fi
+    fi
+    if classifiers=$(extract_setup_cfg_classifiers "$setup_cfg"); then
+      if versions=$(_filter_to_available "$classifiers" "$available"); then
+        echo "$versions"
+        echo "setup-cfg-classifiers"
+        return 0
+      fi
+    fi
+  fi
+
+  # 3) setup.py python_requires / classifiers
+  if [[ -f "$setup_py" ]]; then
+    if constraint=$(extract_setup_py_requires_python "$setup_py"); then
+      if versions=$(parse_version_constraint "$constraint" "$available"); then
+        echo "$versions"
+        echo "setup-py-requires"
+        return 0
+      fi
+    fi
+    if classifiers=$(extract_setup_py_classifiers "$setup_py"); then
+      if versions=$(_filter_to_available "$classifiers" "$available"); then
+        echo "$versions"
+        echo "setup-py-classifiers"
+        return 0
+      fi
+    fi
+  fi
+
+  return 1
+}
+
 # High-level function:
 # - Try requires-python constraint; parse against available versions
 # - Else fallback to classifiers, filter against available versions
@@ -332,21 +549,8 @@ process_python_constraints() {
   fi
 
   if classifiers=$(extract_classifiers_fallback "$file"); then
-    # Filter to those present in available
-    local v
-    for v in $classifiers; do
-      for a in $available; do
-        if [[ "$v" == "$a" ]]; then
-          out="$out $v"
-          break
-        fi
-      done
-    done
-    out=$(echo "$out" | _trim)
-    if [[ -n "$out" ]]; then
-      # Ensure ascending order per available list ordering
-      # Using sort_versions keeps numeric sort consistent
-      sort_versions "$out"
+    if out=$(_filter_to_available "$classifiers" "$available"); then
+      echo "$out"
       return 0
     fi
   fi

--- a/tests/scripts/test_all.sh
+++ b/tests/scripts/test_all.sh
@@ -383,6 +383,7 @@ run_unit_tests() {
     log_section "Unit Tests"
 
     local unit_test_script="$SCRIPT_DIR/unit/test_constraint_utils.sh"
+    local legacy_test_script="$SCRIPT_DIR/unit/test_legacy_extractors.sh"
 
     if [[ -f "$unit_test_script" ]]; then
         log_info "Running constraint utilities unit tests"
@@ -394,6 +395,18 @@ run_unit_tests() {
         fi
     else
         log_warning "Unit test script not found: $unit_test_script"
+    fi
+
+    if [[ -f "$legacy_test_script" ]]; then
+        log_info "Running legacy extractors unit tests"
+        if bash "$legacy_test_script"; then
+            log_success "Legacy extractor tests completed successfully"
+        else
+            log_error "Legacy extractor tests failed"
+            exit 1
+        fi
+    else
+        log_warning "Legacy extractor test script not found: $legacy_test_script"
     fi
 }
 

--- a/tests/scripts/unit/test_legacy_extractors.sh
+++ b/tests/scripts/unit/test_legacy_extractors.sh
@@ -1,0 +1,282 @@
+#!/bin/bash
+
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# Unit tests for the legacy setup.cfg / setup.py extractors and the
+# process_python_constraints_layered helper.
+
+# Do NOT enable `set -e`: many of these tests deliberately invoke functions
+# that return non-zero, then assert against $?.
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+CYAN='\033[0;36m'
+NC='\033[0m'
+
+TOTAL_TESTS=0
+PASSED_TESTS=0
+FAILED_TESTS=0
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TESTS_DIR="$(dirname "$(dirname "$SCRIPT_DIR")")"
+ACTION_DIR="$(dirname "$TESTS_DIR")"
+
+# shellcheck source=../../../lib/constraint_utils.sh
+# shellcheck disable=SC1091
+source "$ACTION_DIR/lib/constraint_utils.sh"
+
+log_success() { echo -e "${GREEN}✅ $1${NC}"; }
+log_error()   { echo -e "${RED}❌ $1${NC}"; }
+log_test()    { echo -e "${BLUE}🔍 Testing: $1${NC}"; }
+log_section() { echo -e "\n${CYAN}=== $1 ===${NC}"; }
+
+assert_eq() {
+    local name="$1" expected="$2" actual="$3"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    if [[ "$expected" == "$actual" ]]; then
+        log_success "$name"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        log_error "$name"
+        echo "   Expected: '$expected'"
+        echo "   Actual:   '$actual'"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+}
+
+assert_rc() {
+    local name="$1" expected="$2" actual="$3"
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    if [[ "$expected" -eq "$actual" ]]; then
+        log_success "$name"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        log_error "$name (expected rc=$expected, got rc=$actual)"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+}
+
+AVAILABLE="3.9 3.10 3.11 3.12 3.13 3.14"
+
+test_setup_cfg() {
+    log_section "extract_setup_cfg_*"
+
+    local d
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+name = foo
+python_requires = >=3.10
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+
+[options]
+packages = find:
+EOF
+
+    log_test "setup.cfg python_requires (underscore)"
+    assert_eq "python_requires" ">=3.10" \
+        "$(extract_setup_cfg_requires_python "$d/setup.cfg")"
+
+    log_test "setup.cfg classifiers"
+    assert_eq "classifiers" "3.10 3.11 3.12" \
+        "$(extract_setup_cfg_classifiers "$d/setup.cfg")"
+
+    rm -rf "$d"
+
+    # Hyphen variant + quoted constraint
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+name = bar
+python-requires = ">=3.9,<3.13"
+EOF
+    log_test "setup.cfg python-requires (hyphen, quoted)"
+    assert_eq "python-requires hyphen" ">=3.9,<3.13" \
+        "$(extract_setup_cfg_requires_python "$d/setup.cfg")"
+    rm -rf "$d"
+
+    # python_requires under [options] (setuptools declarative config).
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+name = qux
+
+[options]
+python_requires = >=3.11
+packages = find:
+EOF
+    log_test "setup.cfg python_requires under [options]"
+    assert_eq "python_requires options" ">=3.11" \
+        "$(extract_setup_cfg_requires_python "$d/setup.cfg")"
+    rm -rf "$d"
+
+    # Missing key
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+name = baz
+EOF
+    log_test "setup.cfg with no python_requires returns rc=1"
+    extract_setup_cfg_requires_python "$d/setup.cfg" >/dev/null 2>&1
+    assert_rc "no python_requires rc" 1 $?
+    rm -rf "$d"
+}
+
+test_setup_py() {
+    log_section "extract_setup_py_*"
+
+    local d
+    d=$(mktemp -d)
+    cat > "$d/setup.py" <<'EOF'
+from setuptools import setup
+setup(
+    name="foo",
+    python_requires=">=3.9,<3.13",
+    classifiers=[
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
+    ],
+)
+EOF
+
+    log_test "setup.py python_requires (double quotes)"
+    assert_eq "py python_requires" ">=3.9,<3.13" \
+        "$(extract_setup_py_requires_python "$d/setup.py")"
+
+    log_test "setup.py classifiers"
+    assert_eq "py classifiers" "3.9 3.10 3.11" \
+        "$(extract_setup_py_classifiers "$d/setup.py")"
+
+    rm -rf "$d"
+
+    # Single-quoted
+    d=$(mktemp -d)
+    cat > "$d/setup.py" <<'EOF'
+from setuptools import setup
+setup(name='bar', python_requires='>=3.10')
+EOF
+    log_test "setup.py python_requires (single quotes)"
+    assert_eq "py python_requires single" ">=3.10" \
+        "$(extract_setup_py_requires_python "$d/setup.py")"
+    rm -rf "$d"
+}
+
+test_layered() {
+    log_section "process_python_constraints_layered"
+
+    # 1) pyproject wins over setup.cfg
+    local d
+    d=$(mktemp -d)
+    cat > "$d/pyproject.toml" <<'EOF'
+[project]
+requires-python = ">=3.11"
+EOF
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+python_requires = >=3.9
+EOF
+    log_test "layered: pyproject takes priority"
+    local out
+    out=$(process_python_constraints_layered "$d" "$AVAILABLE")
+    assert_eq "pyproject versions" "3.11 3.12 3.13 3.14" "$(echo "$out" | sed -n '1p')"
+    assert_eq "pyproject source" "requires-python" "$(echo "$out" | sed -n '2p')"
+    rm -rf "$d"
+
+    # 2) setup.cfg-only with python_requires
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+python_requires = >=3.10
+EOF
+    log_test "layered: setup.cfg requires-python only"
+    out=$(process_python_constraints_layered "$d" "$AVAILABLE")
+    assert_eq "setup.cfg versions" "3.10 3.11 3.12 3.13 3.14" "$(echo "$out" | sed -n '1p')"
+    assert_eq "setup.cfg source" "setup-cfg-requires" "$(echo "$out" | sed -n '2p')"
+    rm -rf "$d"
+
+    # 3) setup.cfg classifiers fallback (no python_requires)
+    d=$(mktemp -d)
+    cat > "$d/setup.cfg" <<'EOF'
+[metadata]
+classifiers =
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+EOF
+    log_test "layered: setup.cfg classifiers fallback"
+    out=$(process_python_constraints_layered "$d" "$AVAILABLE")
+    assert_eq "setup.cfg classifiers versions" "3.10 3.11" "$(echo "$out" | sed -n '1p')"
+    assert_eq "setup.cfg classifiers source" "setup-cfg-classifiers" "$(echo "$out" | sed -n '2p')"
+    rm -rf "$d"
+
+    # 4) setup.py-only with python_requires
+    d=$(mktemp -d)
+    cat > "$d/setup.py" <<'EOF'
+from setuptools import setup
+setup(python_requires=">=3.12")
+EOF
+    log_test "layered: setup.py requires-python only"
+    out=$(process_python_constraints_layered "$d" "$AVAILABLE")
+    assert_eq "setup.py versions" "3.12 3.13 3.14" "$(echo "$out" | sed -n '1p')"
+    assert_eq "setup.py source" "setup-py-requires" "$(echo "$out" | sed -n '2p')"
+    rm -rf "$d"
+
+    # 5) setup.py classifiers fallback
+    d=$(mktemp -d)
+    cat > "$d/setup.py" <<'EOF'
+from setuptools import setup
+setup(classifiers=["Programming Language :: Python :: 3.13"])
+EOF
+    log_test "layered: setup.py classifiers fallback"
+    out=$(process_python_constraints_layered "$d" "$AVAILABLE")
+    assert_eq "setup.py classifiers versions" "3.13" "$(echo "$out" | sed -n '1p')"
+    assert_eq "setup.py classifiers source" "setup-py-classifiers" "$(echo "$out" | sed -n '2p')"
+    rm -rf "$d"
+
+    # 6) Empty directory: nothing declared at all
+    d=$(mktemp -d)
+    log_test "layered: empty dir returns rc=1"
+    process_python_constraints_layered "$d" "$AVAILABLE" >/dev/null 2>&1
+    assert_rc "empty dir rc" 1 $?
+    rm -rf "$d"
+
+    # 7) Directory with unrelated content but no python metadata
+    d=$(mktemp -d)
+    echo "hello" > "$d/README.md"
+    log_test "layered: dir with no python metadata returns rc=1"
+    process_python_constraints_layered "$d" "$AVAILABLE" >/dev/null 2>&1
+    assert_rc "no metadata rc" 1 $?
+    rm -rf "$d"
+}
+
+main() {
+    echo -e "${CYAN}"
+    echo "🧪 Legacy Extractors Unit Test Suite"
+    echo "===================================="
+    echo -e "${NC}"
+
+    test_setup_cfg
+    test_setup_py
+    test_layered
+
+    log_section "Summary"
+    echo "   Total:  $TOTAL_TESTS"
+    echo -e "   ${GREEN}Passed: $PASSED_TESTS${NC}"
+    echo -e "   ${RED}Failed: $FAILED_TESTS${NC}"
+
+    if [[ $FAILED_TESTS -eq 0 ]]; then
+        log_success "All legacy extractor tests passed! 🎉"
+        exit 0
+    else
+        log_error "$FAILED_TESTS test(s) failed"
+        exit 1
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Motivation

`lfreleng-actions/python-supported-versions-action` currently hard-fails on
legacy Python projects that ship only `setup.cfg` + `setup.py` (e.g.
[`lfit/releng-docs-conf`](https://github.com/lfit/releng-docs-conf), which
uses `pbr` and has no `pyproject.toml` at all). See the failing run for
context: <https://github.com/lfit/releng-docs-conf/actions/runs/25146003434>.

We want this action to be the canonical "what Python versions does this
project support?" source for the entire `python-build-action` /
`python-test-action` / `python-audit-action` chain, so it has to:

1. Accept legacy projects (`setup.cfg`-only, `setup.py`-only).
2. Always emit a non-empty `build_python` and `matrix_json`, falling back
   to the EOL-aware list when nothing is declared anywhere.
3. Surface a `versions_source` output so callers can apply policy.

## Changes

### `action.yaml`

* Drop the mandatory `pyproject.toml` check; the directory must still
  exist. Record presence of each metadata file in `HAS_PYPROJECT`,
  `HAS_SETUP_CFG`, `HAS_SETUP_PY` for visibility.
* Source `lib/constraint_utils.sh` from `$GITHUB_ACTION_PATH` and use the
  new layered processor (pyproject → setup.cfg → setup.py).
* Add a new `versions_source` output, with values: `requires-python`,
  `classifiers`, `setup-cfg-requires`, `setup-cfg-classifiers`,
  `setup-py-requires`, `setup-py-classifiers`, `eol-fallback`,
  `static-fallback`.
* Add a new optional `default_python_version` input. When the action
  falls back to the EOL list and this is set (in `X.Y` form), it
  overrides `build_python` only — the matrix still reflects the full
  fallback list.
* When no project-side constraint exists anywhere, emit
  `::warning::No Python version constraint declared…` and continue with
  the EOL-aware (or static) supported-versions list instead of exiting
  non-zero.

### `lib/constraint_utils.sh`

New extractors in the same style as the existing pyproject helpers:

* `extract_setup_cfg_requires_python` — accepts both `python_requires`
  and `python-requires`, single/double quotes, inline `#` comments.
* `extract_setup_cfg_classifiers` — walks the indented multi-line
  `classifiers =` (or `classifier =`) block in `[metadata]`.
* `extract_setup_py_requires_python` — best-effort regex.
* `extract_setup_py_classifiers` — best-effort regex.
* `process_python_constraints_layered <prefix> <available>` — high-level
  helper that probes the three files in priority order and returns
  `<versions>\n<source-token>`. The existing `process_python_constraints`
  is unchanged so all current callers keep working.

### Tests

* New unit suite `tests/scripts/unit/test_legacy_extractors.sh` covering
  the new extractors and the layered processor (pyproject vs setup.cfg
  priority, setup.cfg with `python_requires` only, setup.cfg classifiers
  fallback, setup.py with `python_requires` only, setup.py classifiers
  fallback, empty directory, directory with no Python metadata).
* Wired into `tests/scripts/test_all.sh`.
* Existing test suite continues to pass (39 + 19 + 17 = 75 tests, 0
  failures locally).
* End-to-end smoke tested the composed `action.yaml` script with three
  scenarios: `setup.cfg`-only, empty directory, and empty directory with
  `default_python_version=3.12`. All three produce sane outputs.

### Docs

`README.md` updated to describe:

* The new source-priority (pyproject → setup.cfg → setup.py → fallback).
* The `versions_source` output and all its possible values.
* The `default_python_version` input.
* The "no constraint found → EOL-aware fallback" behaviour and the
  recommendation that callers treat `versions_source=eol-fallback` as a
  soft warning.

## Notes

* No regressions intended for `pyproject.toml` projects. The layered
  processor calls the same `extract_requires_python_constraint` and
  `extract_classifiers_fallback` functions for `pyproject.toml` first.
* All hooks in `pre-commit run --all-files` pass cleanly.