### PR TITLE
Feat: Add setup.cfg metadata source support

### DIFF
--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -180,10 +180,186 @@ jobs:
       - name: 'Validate missing pyproject.toml failure'
         run: |
           if [ "${{ steps.test-missing.outcome }}" != "failure" ]; then
-            echo "Error: Expected test to fail due to missing pyproject.toml"
+            echo "Error: Expected test to fail due to missing metadata files"
             exit 1
           fi
-          echo "Test correctly failed due to missing pyproject.toml"
+          echo "Test correctly failed when neither pyproject.toml nor setup.cfg exists"
+
+  ### Test setup.cfg Fixtures ###
+  # Exercise the legacy setuptools / PBR code path end-to-end against
+  # every setup.cfg fixture in tests/fixtures/. Each matrix entry copies
+  # one fixture into a freshly created workspace as 'setup.cfg' (with no
+  # accompanying pyproject.toml) and asserts the action's outputs.
+  test-setup-cfg-fixtures:
+    name: 'Test setup.cfg Fixtures'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 8
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: requires-python-basic
+            file: tests/fixtures/setup_cfg_requires_python_basic.cfg
+            expected_versions: "3.10 3.11 3.12 3.13 3.14"
+            expected_build: "3.14"
+            expected_source: "setup.cfg"
+            should_fail: 'false'
+          - name: classifiers-only
+            file: tests/fixtures/setup_cfg_classifiers_only.cfg
+            expected_versions: "3.11 3.12 3.13"
+            expected_build: "3.13"
+            expected_source: "setup.cfg"
+            should_fail: 'false'
+          - name: pbr-legacy
+            file: tests/fixtures/setup_cfg_pbr_legacy.cfg
+            expected_versions: "3.10 3.11 3.12 3.13 3.14"
+            expected_build: "3.14"
+            expected_source: "setup.cfg"
+            should_fail: 'false'
+          - name: range-constraint
+            file: tests/fixtures/setup_cfg_range_constraint.cfg
+            expected_versions: "3.11 3.12"
+            expected_build: "3.12"
+            expected_source: "setup.cfg"
+            should_fail: 'false'
+          - name: exact-constraint
+            file: tests/fixtures/setup_cfg_exact_constraint.cfg
+            expected_versions: "3.12"
+            expected_build: "3.12"
+            expected_source: "setup.cfg"
+            should_fail: 'false'
+          - name: no-python-info
+            file: tests/fixtures/setup_cfg_no_python_info.cfg
+            should_fail: 'true'
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 'Prepare setup.cfg fixture workspace'
+        run: |
+          set -euo pipefail
+          workdir="setup-cfg-fixture-${{ matrix.name }}"
+          mkdir -p "$workdir"
+          cp "${{ matrix.file }}" "$workdir/setup.cfg"
+          # Deliberately do NOT create a pyproject.toml so the action
+          # is forced down the setup.cfg branch.
+          echo "WORKDIR=$workdir" >> "$GITHUB_ENV"
+
+      - name: 'Run action on setup.cfg fixture (offline)'
+        id: run
+        uses: ./
+        with:
+          path_prefix: '${{ env.WORKDIR }}/'
+          offline_mode: 'true'
+        continue-on-error: ${{ matrix.should_fail == 'true' }}
+
+      - name: 'Assert outputs for setup.cfg fixture'
+        if: matrix.should_fail != 'true'
+        run: |
+          set -euo pipefail
+          echo "Supported versions: '${{ steps.run.outputs.supported_versions }}'"
+          echo "Build Python: '${{ steps.run.outputs.build_python }}'"
+          echo "Metadata source: '${{ steps.run.outputs.metadata_source }}'"
+
+          actual_json=$(echo '${{ steps.run.outputs.matrix_json }}' | jq -c .)
+          echo "Matrix JSON: '$actual_json'"
+
+          if [ "${{ steps.run.outputs.build_python }}" != "${{ matrix.expected_build }}" ]; then
+            echo "Error: build_python mismatch (expected '${{ matrix.expected_build }}')"
+            exit 1
+          fi
+          if [ "${{ steps.run.outputs.supported_versions }}" != "${{ matrix.expected_versions }}" ]; then
+            echo "Error: supported_versions mismatch (expected '${{ matrix.expected_versions }}')"
+            exit 1
+          fi
+          if [ "${{ steps.run.outputs.metadata_source }}" != "${{ matrix.expected_source }}" ]; then
+            echo "Error: metadata_source mismatch (expected '${{ matrix.expected_source }}')"
+            exit 1
+          fi
+
+          expected_json=$(printf '%s\n' "${{ matrix.expected_versions }}" | tr ' ' '\n' | jq -R . | jq -s -c '{"python-version": .}')
+          if [ "$expected_json" != "$actual_json" ]; then
+            echo "Error: matrix_json mismatch"
+            echo "Expected: $expected_json"
+            echo "Actual:   $actual_json"
+            exit 1
+          fi
+          echo "setup.cfg fixture '${{ matrix.name }}' passed ✅"
+
+      - name: 'Assert failure for setup.cfg fixture'
+        if: matrix.should_fail == 'true'
+        run: |
+          if [ "${{ steps.run.outcome }}" != "failure" ]; then
+            echo "Error: Expected fixture '${{ matrix.name }}' to fail but it succeeded"
+            exit 1
+          fi
+          echo "setup.cfg fixture '${{ matrix.name }}' correctly failed ✅"
+
+  ### Test Metadata Source Precedence ###
+  # Confirm that when BOTH pyproject.toml and setup.cfg are present in
+  # the same directory, the action consults pyproject.toml first and
+  # ignores setup.cfg. This is the documented contract: setup.cfg is a
+  # fallback for legacy projects, not an override for PEP 621 metadata.
+  test-metadata-source-precedence:
+    name: 'Test Metadata Source Precedence'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 5
+    steps:
+      - name: 'Checkout repository'
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: 'Prepare mixed-metadata workspace'
+        run: |
+          set -euo pipefail
+          mkdir -p mixed-metadata
+          # pyproject.toml declares >=3.12; setup.cfg declares >=3.10.
+          # If precedence works correctly, only 3.12+ should appear.
+          cat > mixed-metadata/pyproject.toml <<'TOML'
+          [project]
+          name = "mixed"
+          version = "0.1.0"
+          requires-python = ">=3.12"
+          TOML
+          cat > mixed-metadata/setup.cfg <<'CFG'
+          [metadata]
+          name = mixed
+          classifiers =
+              Programming Language :: Python :: 3.10
+              Programming Language :: Python :: 3.11
+
+          [options]
+          python_requires = >=3.10
+          CFG
+
+      - name: 'Run action on mixed-metadata project'
+        id: run
+        uses: ./
+        with:
+          path_prefix: 'mixed-metadata/'
+          offline_mode: 'true'
+
+      - name: 'Assert pyproject.toml took precedence'
+        run: |
+          set -euo pipefail
+          source="${{ steps.run.outputs.metadata_source }}"
+          versions="${{ steps.run.outputs.supported_versions }}"
+          echo "Metadata source: $source"
+          echo "Supported versions: $versions"
+          if [ "$source" != "pyproject.toml" ]; then
+            echo "Error: expected metadata_source='pyproject.toml', got '$source'"
+            exit 1
+          fi
+          # The pyproject.toml requires >=3.12; ensure 3.10/3.11 (from
+          # setup.cfg) did not leak into the result.
+          if echo "$versions" | grep -qE '(^| )3\.1[01]( |$)'; then
+            echo "Error: setup.cfg values leaked through; got '$versions'"
+            exit 1
+          fi
+          echo "Precedence honoured ✅"
 
   ### Test Poetry Fixtures ###
   test-poetry-fixtures:

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@
 *.cfg
 !.isort.cfg
 !setup.cfg
+# Allow setup.cfg test fixtures used by the test suite to exercise the
+# legacy setuptools / PBR metadata path. Without this exception, the
+# generic *.cfg ignore swallows them and CI silently regresses.
+!tests/fixtures/setup_cfg_*.cfg
 *.orig
 *.log
 *.pot

--- a/README.md
+++ b/README.md
@@ -5,23 +5,36 @@
 
 # 🐍 Extract Python Versions Supported by Project
 
-Parses pyproject.toml and extracts the Python versions supported by the
-project. Determines the most recent version supported and provides JSON
-representing all supported versions, for use in GitHub matrix jobs.
+Parses a project's declarative metadata and extracts the Python versions
+supported by it. Determines the most recent version supported and provides
+JSON representing all supported versions, for use in GitHub matrix jobs.
 
-**Primary Method**: Extracts from `requires-python` constraint
-(e.g. `requires-python = ">=3.10"`)
-**Fallback Method**: Parses `Programming Language :: Python ::` classifiers
+**Metadata sources** (consulted in order, first hit wins):
+
+1. `pyproject.toml` (PEP 517/518/621) — the canonical modern format.
+2. `setup.cfg` (legacy declarative setuptools / PBR) — the fallback for
+   older projects that have not migrated to PEP 621.
+
+**Within each source**, the action prefers an explicit version constraint
+before falling back to classifier-derived versions:
+
+- **Primary method**: `requires-python` (pyproject.toml) or
+  `python_requires` under `[options]` (setup.cfg), e.g.
+  `requires-python = ">=3.10"`.
+- **Fallback method**: `Programming Language :: Python :: X.Y` Trove
+  classifiers. The action recognises both `classifiers` and the legacy
+  PBR `classifier` key in setup.cfg.
 
 This brings alignment with actions/setup-python behavior while maintaining
-compatibility with projects that use explicit version classifiers.
+compatibility with projects that use explicit version classifiers and with
+legacy setuptools/PBR projects that have not yet adopted pyproject.toml.
 
 **Dynamic Version Detection with EOL Awareness**: The action automatically
 fetches the latest supported Python versions from official sources, filtering
 out end-of-life (EOL) versions to ensure projects use supported Python versions.
 This provides up-to-date, secure version information without manual updates.
 If the network call fails, the action will continue with a warning and rely
-solely on the constraints found in pyproject.toml.
+solely on the constraints found in your project metadata.
 
 ## python-supported-versions-action
 
@@ -128,6 +141,7 @@ Error: Python 3.8 became unsupported/EOL on date: 2024-10-07 🛑
 | build_python       | Most recent Python version supported by project         |
 | matrix_json        | All Python versions supported by project as JSON string |
 | supported_versions | Space-separated list of all supported Python versions   |
+| metadata_source    | `pyproject.toml` or `setup.cfg` (source file consulted) |
 
 <!-- markdownlint-enable MD013 -->
 
@@ -155,14 +169,47 @@ A workflow calling this action will produce the output below:
 
 ```console
 Retrieved supported Python versions from API service 🌍
-Supported versions: 3.9 3.10 3.11 3.12 3.13 3.14
-Found requires-python constraint (via fallback): >=3.10
-🔍 Processed requires-python constraint
+Supported versions: 3.10 3.11 3.12 3.13 3.14
+Found requires-python constraint (via Python): >=3.10
+Metadata source: pyproject.toml
 Python versions from constraints: 3.10 3.11 3.12 3.13 3.14
 ✅ Build Python: 3.14
 ✅ Supported versions: 3.10 3.11 3.12 3.13 3.14
 ✅ Matrix JSON: {"python-version":["3.10","3.11","3.12","3.13","3.14"]}
 ```
+
+## Legacy setuptools / PBR (`setup.cfg`) Support
+
+Projects that pre-date PEP 621 — in particular OpenStack / PBR projects —
+often carry their declarative metadata in `setup.cfg` rather than
+`pyproject.toml`. The action handles both layouts transparently.
+
+The primary source is `python_requires` under `[options]`:
+
+```ini
+[options]
+python_requires = >=3.10
+```
+
+When `python_requires` is absent the action falls back to Trove classifiers
+under `[metadata]`. The action recognises both the modern `classifiers` key
+and the legacy PBR `classifier` (singular) key, and combines entries from
+both keys in first-seen order:
+
+```ini
+[metadata]
+name = lfdocs_conf
+classifier =
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+```
+
+When both `pyproject.toml` and `setup.cfg` exist in the same directory the
+action consults `pyproject.toml` first, then falls back to `setup.cfg`
+whenever `pyproject.toml` is absent **or** contains no Python version
+metadata. The `metadata_source` output reports which file supplied the
+answer, allowing downstream actions to react accordingly.
 
 ## Implementation Details
 
@@ -172,9 +219,9 @@ The action first attempts to extract the `requires-python` constraint from
 pyproject.toml:
 
 ```toml
-requires-python = ">=3.10"    # Supports 3.10, 3.11, 3.12, 3.13, 3.14
-requires-python = ">3.9"      # Supports 3.10, 3.11, 3.12, 3.13, 3.14
-requires-python = "==3.11"    # Supports 3.11 specifically
+requires-python = ">=3.10"   # Supports 3.10, 3.11, 3.12, 3.13, 3.14
+requires-python = ">3.10"    # Supports 3.11, 3.12, 3.13, 3.14
+requires-python = "==3.11"   # Supports 3.11 specifically
 ```
 
 The action evaluates the constraint against supported Python versions
@@ -204,7 +251,7 @@ from `tool.poetry.dependencies.python`:
 [tool.poetry.dependencies]
 python = "^3.10"     # Caret constraint: >=3.10,<4.0
 python = "~=3.11"    # Compatible release: >=3.11,<3.12
-python = ">=3.9,<3.13"  # Range constraint
+python = ">=3.10,<3.13"  # Range constraint
 ```
 
 Poetry constraints are automatically normalized to standard PEP 440 format
@@ -238,12 +285,25 @@ self-contained, portable solution that doesn't require external dependencies.
 - `fetch_python_data()` - Fetches Python version data from endoflife.date API
 - `check_version_eol()` - Checks if a Python version is end-of-life
 - `normalize_constraint()` - Handles Poetry caret (^) and tilde (~=) constraints
-- `extract_requires_python_constraint()` - Extracts requires-python from pyproject.toml
-- `extract_classifiers_fallback()` - Extracts Python versions from classifiers
+- `extract_requires_python_python()` / `extract_requires_python_fallback()` -
+  Extract `requires-python` from `pyproject.toml` (Python TOML parser primary,
+  grep/sed fallback)
+- `extract_classifiers_fallback()` - Extracts Python versions from
+  `pyproject.toml` classifiers (order-preserving dedup)
+- `extract_requires_python_setup_cfg()` - Extract `python_requires` from
+  `setup.cfg` (`configparser` primary, awk fallback)
+- `extract_classifiers_setup_cfg()` - Extracts Python versions from `setup.cfg`
+  `[metadata].classifiers` (modern) or `[metadata].classifier` (legacy PBR)
 - `parse_version_constraint()` - Parses and applies version constraints
 - `handle_eol_versions()` - Processes EOL versions based on eol_behaviour setting
 - `generate_matrix_json()` - Creates GitHub Actions matrix JSON
 - `get_build_version()` - Determines latest version for builds
+
+A mirror implementation of the extractor helpers lives under `lib/` and
+backs the test suite. Keep both copies in sync; the test job
+`test-comprehensive` covers the lib path while the `test-setup-cfg-fixtures`
+and `test-metadata-source-precedence` jobs exercise the live `action.yaml`
+implementation end-to-end.
 
 **Design Benefits:**
 
@@ -265,14 +325,13 @@ actively maintained Python versions remain available.
 
 1. Fetches EOL data from `https://endoflife.date/api/python.json`
 2. Filters out versions that have reached end-of-life
-3. Returns Python 3.9+ versions that are still supported
+3. Returns Python 3.10+ versions that are still supported
 4. Provides real-time security compliance
 
 **Fallback Mechanism:**
 If network access is unavailable or the API request fails, the action falls
 back to a static definition of supported Python versions:
 
-- Python 3.9
 - Python 3.10
 - Python 3.11
 - Python 3.12
@@ -297,13 +356,13 @@ maintainability.
    are still supported
 
 2. **Version Filtering**: Parses the JSON response to extract:
-   - Python version cycles (e.g., "3.9", "3.10", "3.11")
+   - Python version cycles (e.g., "3.10", "3.11", "3.12")
    - End-of-life dates for each version
 
 3. **EOL Comparison**: Compares current date against EOL dates to filter
    out versions that are no longer supported
 
-4. **Version Selection**: Returns Python 3.9+ versions that are:
+4. **Version Selection**: Returns Python 3.10+ versions that are:
    - Not end-of-life (still receiving security updates)
    - Actively maintained by the Python core team
 
@@ -321,7 +380,7 @@ The action includes an `offline_mode` input for environments without internet ac
 When using offline mode:
 
 - Network requests do not occur
-- Uses internal static version list: 3.9, 3.10, 3.11, 3.12, 3.13, 3.14
+- Uses internal static version list: 3.10, 3.11, 3.12, 3.13, 3.14
 - EOL filtering does not occur
 - Perfect for air-gapped or restricted network environments
 
@@ -354,21 +413,21 @@ When dynamic fetching with EOL filtering is successful:
 
 ```text
 Retrieved supported Python versions from API service 🌍
-Supported versions: 3.9 3.10 3.11 3.12 3.13 3.14
+Supported versions: 3.10 3.11 3.12 3.13 3.14
 ```
 
 When using offline mode:
 
 ```text
 Using internal supported Python versions (offline mode) 📴
-Supported versions: 3.9 3.10 3.11 3.12 3.13 3.14
+Supported versions: 3.10 3.11 3.12 3.13 3.14
 ```
 
 When the endoflife.date API is unavailable:
 
 ```text
 Unable to retrieve supported Python versions, using internal list ⚠️
-Supported versions: 3.9 3.10 3.11 3.12 3.13 3.14
+Supported versions: 3.10 3.11 3.12 3.13 3.14
 ```
 
 ## Testing
@@ -403,8 +462,8 @@ The action handles these scenarios:
 
 Current Python EOL schedule (as of 2025):
 
-- **Python 3.8**: EOL October 7, 2024 (excluded by default)
-- **Python 3.9**: EOL October 31, 2025 (included)
+- **Python 3.8**: EOL October 7, 2024 (excluded)
+- **Python 3.9**: EOL October 31, 2025 (excluded)
 - **Python 3.10**: EOL October 31, 2026 (included)
 - **Python 3.11**: EOL October 31, 2027 (included)
 - **Python 3.12**: EOL October 31, 2028 (included)

--- a/action.yaml
+++ b/action.yaml
@@ -48,6 +48,13 @@ outputs:
   supported_versions:
     description: "Space-separated list of all supported Python versions"
     value: "${{ steps.versions.outputs.supported_versions }}"
+  metadata_source:
+    description: >-
+      Project metadata file used to derive the Python version set:
+      'pyproject.toml' or 'setup.cfg'. Useful for downstream actions
+      that need to know whether legacy setuptools metadata was the
+      source of truth.
+    value: "${{ steps.versions.outputs.metadata_source }}"
 
 runs:
   using: "composite"
@@ -72,16 +79,26 @@ runs:
         OFFLINE_MODE="${INPUT_OFFLINE_MODE}"
 
 
-        # Internal list of supported Python versions (requires periodic update)
-        INTERNAL_SUPPORTED_VERSIONS="3.9 3.10 3.11 3.12 3.13 3.14"
+        # Internal list of supported Python versions (requires periodic update).
+        # Python 3.9 reached end-of-life in October 2025 and is no longer
+        # included in the static fallback; remove or extend this list when
+        # the upstream Python release cadence changes.
+        INTERNAL_SUPPORTED_VERSIONS="3.10 3.11 3.12 3.13 3.14"
 
         # Setup and validate environment
         path_prefix="${INPUT_PATH_PREFIX}"
         path_prefix="${path_prefix:-'.'}"
         path_prefix="${path_prefix%/}"
 
-        # Set PYPROJECT_FILE after path normalization
+        # Candidate project-metadata files. The action accepts either of
+        # the two declarative formats:
+        #   * pyproject.toml — PEP 517/518/621 (preferred; canonical)
+        #   * setup.cfg     — Legacy declarative setuptools / PBR
+        # Precedence is pyproject.toml first; setup.cfg is consulted only
+        # when pyproject.toml is absent OR present but devoid of usable
+        # Python version metadata.
         PYPROJECT_FILE="${path_prefix}/pyproject.toml"
+        SETUP_CFG_FILE="${path_prefix}/setup.cfg"
 
         # Check tool availability
         if ! command -v jq >/dev/null 2>&1; then
@@ -97,14 +114,16 @@ runs:
         fi
 
 
-        # Validate directory and pyproject.toml existence
+        # Validate directory and metadata file existence. Either
+        # pyproject.toml or setup.cfg is sufficient; the action only
+        # fails when neither candidate exists.
         if [[ ! -d "$path_prefix" ]]; then
           echo 'Error: invalid path/prefix to project directory ❌'
           exit 1
         fi
 
-        if [[ ! -f "$path_prefix/pyproject.toml" ]]; then
-          echo 'Error: missing pyproject.toml file ❌'
+        if [[ ! -f "$PYPROJECT_FILE" && ! -f "$SETUP_CFG_FILE" ]]; then
+          echo "Error: neither pyproject.toml nor setup.cfg found in $path_prefix ❌"
           exit 1
         fi
 
@@ -402,12 +421,15 @@ runs:
                 return 1
             fi
 
-            # Extract Python versions from Programming Language classifiers
-            # Support both single and double quotes, ignore commented lines
+            # Extract Python versions from Programming Language classifiers.
+            # Preserves source order via awk dedup (first-seen wins) instead
+            # of `sort -u`, which would sort lexicographically and place
+            # '3.10' before '3.9' — a real problem once the matrix spans
+            # the 3.9 -> 3.10 boundary.
             classifiers=$(grep -v '^[[:space:]]*#' "$pyproject_file" 2>/dev/null | \
                           grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+' | \
                           grep -oE '[0-9]+\.[0-9]+' | \
-                          sort -u | tr '\n' ' ' | sed 's/ *$//')
+                          awk '!seen[$0]++' | tr '\n' ' ' | sed 's/ *$//')
 
             if [[ -n "$classifiers" ]]; then
                 printf '%s\n' "$classifiers"
@@ -415,6 +437,125 @@ runs:
             else
                 return 1
             fi
+        }
+
+        # Function: Extract python_requires from setup.cfg via configparser.
+        # Falls back to awk-based extraction when python3 is unavailable
+        # (vanishingly rare on GitHub-hosted runners, but supported for
+        # bring-your-own-runner setups).
+        extract_requires_python_setup_cfg() {
+            local cfg_file="$1"
+            [[ -f "$cfg_file" ]] || return 1
+
+            if command -v python3 >/dev/null 2>&1; then
+                local val
+                val=$(python3 - "$cfg_file" <<'PY' 2>/dev/null
+        import configparser, sys
+        cfg = configparser.ConfigParser()
+        try:
+            cfg.read(sys.argv[1])
+        except configparser.Error:
+            sys.exit(1)
+        val = cfg.get("options", "python_requires", fallback=None)
+        if val is None:
+            sys.exit(1)
+        val = val.strip().strip("'\"")
+        if not val:
+            sys.exit(1)
+        print(val)
+        PY
+                ) || val=""
+                if [[ -n "$val" ]]; then
+                    printf '%s\n' "$val"
+                    return 0
+                fi
+            fi
+
+            # Fallback: awk-based extraction limited to the canonical key
+            # name and single-line values — sufficient for the vast
+            # majority of real-world setup.cfg files.
+            local constraint
+            constraint=$(awk '
+              BEGIN { insec = 0 }
+              /^[[:space:]]*[#;]/ { next }
+              /^\[/ {
+                insec = ($0 ~ /^\[options\][[:space:]]*$/) ? 1 : 0
+                next
+              }
+              insec && /^[[:space:]]*python_requires[[:space:]]*=/ {
+                sub(/^[[:space:]]*python_requires[[:space:]]*=[[:space:]]*/, "")
+                sub(/[[:space:]]*$/, "")
+                gsub(/^["\x27]|["\x27]$/, "")
+                print
+                exit
+              }
+            ' "$cfg_file" 2>/dev/null)
+
+            if [[ -n "$constraint" ]]; then
+                printf '%s\n' "$constraint"
+                return 0
+            fi
+            return 1
+        }
+
+        # Function: Extract Programming Language classifiers from setup.cfg.
+        # Handles both the modern setuptools key ('classifiers', plural)
+        # and the legacy PBR/distutils key ('classifier', singular) under
+        # [metadata]. Either or both may be present; merge the results.
+        extract_classifiers_setup_cfg() {
+            local cfg_file="$1"
+            [[ -f "$cfg_file" ]] || return 1
+
+            if command -v python3 >/dev/null 2>&1; then
+                local versions
+                versions=$(python3 - "$cfg_file" <<'PY' 2>/dev/null
+        import configparser, re, sys
+        cfg = configparser.ConfigParser()
+        try:
+            cfg.read(sys.argv[1])
+        except configparser.Error:
+            sys.exit(1)
+        raw = []
+        for key in ("classifiers", "classifier"):
+            val = cfg.get("metadata", key, fallback=None)
+            if val:
+                raw.append(val)
+        if not raw:
+            sys.exit(1)
+        seen = []
+        for block in raw:
+            for line in block.splitlines():
+                m = re.search(r"Programming Language :: Python :: (\d+\.\d+)(?![.\d])", line)
+                if m and m.group(1) not in seen:
+                    seen.append(m.group(1))
+        if not seen:
+            sys.exit(1)
+        print(" ".join(seen))
+        PY
+                ) || versions=""
+                if [[ -n "$versions" ]]; then
+                    printf '%s\n' "$versions"
+                    return 0
+                fi
+            fi
+
+            # Fallback: grep over the raw file. Continuation lines for
+            # classifier values in setup.cfg are indented, so the regex
+            # catches them irrespective of section structure.
+            local lines versions
+            lines=$(grep -v '^[[:space:]]*[#;]' "$cfg_file" 2>/dev/null | \
+                    grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+') || true
+            if [[ -z "$lines" ]]; then
+                return 1
+            fi
+            versions=$(echo "$lines" | grep -oE 'Python :: [0-9]+\.[0-9]+' | \
+                       grep -oE '[0-9]+\.[0-9]+' | awk '!seen[$0]++' | \
+                       tr '\n' ' ' | sed 's/ $//')
+            if [[ -n "$versions" ]]; then
+                printf '%s\n' "$versions"
+                return 0
+            fi
+            return 1
         }
 
         # Function: Parse version constraint and return all matching versions
@@ -737,32 +878,73 @@ runs:
         fi
         echo "Supported versions: $SUPPORTED_VERSIONS"
 
-        # Extract requires-python constraint
+        # Extract requires-python constraint and Python classifiers.
+        #
+        # Source precedence:
+        #   1. pyproject.toml  — PEP 621 'requires-python' and
+        #                       project.classifiers (or Poetry deps).
+        #   2. setup.cfg       — [options] python_requires and
+        #                       [metadata] classifiers / classifier.
+        #
+        # When both files exist we consult pyproject.toml first and only
+        # consult setup.cfg if pyproject.toml yielded nothing usable.
+        # METADATA_SOURCE is emitted as a workflow output so downstream
+        # actions (e.g. python-build-action) can react to the project's
+        # canonical metadata format.
         REQUIRES_PYTHON=""
-        if command -v python3 >/dev/null 2>&1; then
-            if REQUIRES_PYTHON=$(extract_requires_python_python "$PYPROJECT_FILE"); then
-              echo "Found requires-python constraint (via Python): $REQUIRES_PYTHON"
-            fi
-        fi
-
-        # Fall back to grep/sed parsing if Python parsing failed
-        if [[ -z "$REQUIRES_PYTHON" ]]; then
-            if REQUIRES_PYTHON=$(extract_requires_python_fallback "$PYPROJECT_FILE"); then
-              echo "Found requires-python constraint (via fallback): $REQUIRES_PYTHON"
-            fi
-        fi
-
-        # Extract classifiers fallback
         CLASSIFIERS=""
-        if CLASSIFIERS=$(extract_classifiers_fallback "$PYPROJECT_FILE"); then
-          echo "Programming Language classifiers: $CLASSIFIERS"
+        METADATA_SOURCE=""
+
+        # --- Phase 1: pyproject.toml ---------------------------------------
+        if [[ -f "$PYPROJECT_FILE" ]]; then
+            if command -v python3 >/dev/null 2>&1; then
+                if REQUIRES_PYTHON=$(extract_requires_python_python "$PYPROJECT_FILE"); then
+                  echo "Found requires-python constraint (via Python): $REQUIRES_PYTHON"
+                fi
+            fi
+
+            if [[ -z "$REQUIRES_PYTHON" ]]; then
+                if REQUIRES_PYTHON=$(extract_requires_python_fallback "$PYPROJECT_FILE"); then
+                  echo "Found requires-python constraint (via fallback): $REQUIRES_PYTHON"
+                fi
+            fi
+
+            if CLASSIFIERS=$(extract_classifiers_fallback "$PYPROJECT_FILE"); then
+              echo "Programming Language classifiers (pyproject.toml): $CLASSIFIERS"
+            fi
+
+            if [[ -n "$REQUIRES_PYTHON" || -n "$CLASSIFIERS" ]]; then
+                METADATA_SOURCE="pyproject.toml"
+            fi
+        fi
+
+        # --- Phase 2: setup.cfg (only if phase 1 produced nothing) ---------
+        if [[ -z "$METADATA_SOURCE" && -f "$SETUP_CFG_FILE" ]]; then
+            echo "ℹ️  pyproject.toml absent or empty of Python version metadata; consulting setup.cfg"
+            if REQUIRES_PYTHON=$(extract_requires_python_setup_cfg "$SETUP_CFG_FILE"); then
+              echo "Found python_requires constraint (setup.cfg): $REQUIRES_PYTHON"
+            fi
+            if CLASSIFIERS=$(extract_classifiers_setup_cfg "$SETUP_CFG_FILE"); then
+              echo "Programming Language classifiers (setup.cfg): $CLASSIFIERS"
+            fi
+            if [[ -n "$REQUIRES_PYTHON" || -n "$CLASSIFIERS" ]]; then
+                METADATA_SOURCE="setup.cfg"
+            fi
         fi
 
         # Check if any constraints were found
         if [[ -z "$REQUIRES_PYTHON" && -z "$CLASSIFIERS" ]]; then
-          echo "Error: No Python version constraints found in $PYPROJECT_FILE ❌"
+          if [[ -f "$PYPROJECT_FILE" && -f "$SETUP_CFG_FILE" ]]; then
+            echo "Error: no Python version constraints found in $PYPROJECT_FILE or $SETUP_CFG_FILE ❌"
+          elif [[ -f "$PYPROJECT_FILE" ]]; then
+            echo "Error: no Python version constraints found in $PYPROJECT_FILE ❌"
+          else
+            echo "Error: no Python version constraints found in $SETUP_CFG_FILE ❌"
+          fi
           exit 1
         fi
+
+        echo "Metadata source: $METADATA_SOURCE"
 
         # Process constraints and determine requested versions
         REQUESTED_PYTHON_VERSIONS=""
@@ -832,6 +1014,7 @@ runs:
           echo "__PY_MATRIX_JSON__"
         } >> "$GITHUB_OUTPUT"
         echo "supported_versions=$FINAL_PYTHON_VERSIONS" >> "$GITHUB_OUTPUT"
+        echo "metadata_source=$METADATA_SOURCE" >> "$GITHUB_OUTPUT"
 
         # Final clean output
         echo "✅ Build Python: $BUILD_PYTHON"

--- a/lib/constraint_utils.sh
+++ b/lib/constraint_utils.sh
@@ -203,6 +203,135 @@ parse_version_constraint() {
   return 0
 }
 
+# Extract requires-python constraint from a setup.cfg file.
+# Returns 0 with the constraint on stdout, or 1 if absent / file missing.
+#
+# Looks at [options] python_requires = <constraint>. The PEP 517/518
+# declarative setuptools format does not quote the value, so we do not
+# strip quotes here (configparser-level helper below handles both).
+extract_requires_python_setup_cfg() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  # Prefer Python's configparser if Python 3 is available — INI parsing
+  # rules (continuation lines, comment markers, case-insensitive keys)
+  # are non-trivial and easy to get wrong with grep/sed.
+  if command -v python3 >/dev/null 2>&1; then
+    local val
+    val=$(python3 - "$file" <<'PY' 2>/dev/null
+import configparser, sys
+cfg = configparser.ConfigParser()
+try:
+    cfg.read(sys.argv[1])
+except configparser.Error:
+    sys.exit(1)
+val = cfg.get("options", "python_requires", fallback=None)
+if val is None:
+    sys.exit(1)
+val = val.strip().strip("'\"")
+if not val:
+    sys.exit(1)
+print(val)
+PY
+) || val=""
+    if [[ -n "$val" ]]; then
+      echo "$val"
+      return 0
+    fi
+  fi
+
+  # Fallback: awk-based extraction. Limited to single-line values and
+  # the canonical key name; sufficient for the overwhelming majority
+  # of real-world setup.cfg files.
+  local constraint
+  constraint=$(awk '
+    BEGIN { insec = 0 }
+    /^[[:space:]]*[#;]/ { next }
+    /^\[/ {
+      insec = ($0 ~ /^\[options\][[:space:]]*$/) ? 1 : 0
+      next
+    }
+    insec && /^[[:space:]]*python_requires[[:space:]]*=/ {
+      sub(/^[[:space:]]*python_requires[[:space:]]*=[[:space:]]*/, "")
+      sub(/[[:space:]]*$/, "")
+      gsub(/^["\x27]|["\x27]$/, "")
+      print
+      exit
+    }
+  ' "$file" 2>/dev/null)
+
+  if [[ -n "$constraint" ]]; then
+    echo "$constraint"
+    return 0
+  fi
+  return 1
+}
+
+# Extract Python versions from Programming Language classifiers in setup.cfg.
+# Supports both the modern setuptools key (`classifiers`) and the legacy
+# PBR/distutils key (`classifier`) under [metadata]. Classifier values in
+# setup.cfg are typically multi-line indented blocks.
+# Prints space-separated versions in first-seen order; returns 0 on success.
+extract_classifiers_setup_cfg() {
+  local file="$1"
+  [[ -f "$file" ]] || return 1
+
+  if command -v python3 >/dev/null 2>&1; then
+    local versions
+    versions=$(python3 - "$file" <<'PY' 2>/dev/null
+import configparser, re, sys
+cfg = configparser.ConfigParser()
+try:
+    cfg.read(sys.argv[1])
+except configparser.Error:
+    sys.exit(1)
+# Modern setuptools uses 'classifiers'; PBR and legacy distutils use
+# the singular 'classifier'. Some files include both; merge them.
+raw = []
+for key in ("classifiers", "classifier"):
+    val = cfg.get("metadata", key, fallback=None)
+    if val:
+        raw.append(val)
+if not raw:
+    sys.exit(1)
+seen = []
+for block in raw:
+    for line in block.splitlines():
+        m = re.search(r"Programming Language :: Python :: (\d+\.\d+)(?![.\d])", line)
+        if m and m.group(1) not in seen:
+            seen.append(m.group(1))
+if not seen:
+    sys.exit(1)
+print(" ".join(seen))
+PY
+) || versions=""
+    if [[ -n "$versions" ]]; then
+      echo "$versions"
+      return 0
+    fi
+  fi
+
+  # Fallback: a simpler grep over the raw file. Continuation lines for
+  # classifier values in setup.cfg start with whitespace, so grepping
+  # for the well-known classifier pattern catches them regardless of
+  # section structure. This is intentionally permissive — the Python
+  # path above is preferred.
+  local lines versions
+  lines=$(grep -v '^[[:space:]]*[#;]' "$file" 2>/dev/null | \
+          grep -E 'Programming Language :: Python :: [0-9]+\.[0-9]+') || true
+  if [[ -z "$lines" ]]; then
+    return 1
+  fi
+  versions=$(echo "$lines" | grep -oE 'Python :: [0-9]+\.[0-9]+' | \
+             grep -oE '[0-9]+\.[0-9]+' | awk '!seen[$0]++' | \
+             tr '\n' ' ' | sed 's/ $//')
+  if [[ -n "$versions" ]]; then
+    echo "$versions"
+    return 0
+  fi
+  return 1
+}
+
 # Extract requires-python constraint from a TOML file (best-effort, grep-based)
 # Prints the constraint and returns 0 on success; returns 1 on failure/not found.
 extract_requires_python_constraint() {
@@ -351,5 +480,70 @@ process_python_constraints() {
     fi
   fi
 
+  return 1
+}
+
+# High-level function for setup.cfg sources. Mirrors process_python_constraints
+# but reads python_requires from [options] and classifiers from [metadata].
+# Returns 0 printing space-separated versions, or 1 if none determinable.
+process_python_constraints_setup_cfg() {
+  local file="$1"
+  local available="$2"
+
+  [[ -f "$file" ]] || return 1
+  [[ -n "$available" ]] || return 1
+
+  local constraint versions classifiers out=""
+  if constraint=$(extract_requires_python_setup_cfg "$file"); then
+    if versions=$(parse_version_constraint "$constraint" "$available"); then
+      echo "$versions"
+      return 0
+    fi
+  fi
+
+  if classifiers=$(extract_classifiers_setup_cfg "$file"); then
+    local v a
+    for v in $classifiers; do
+      for a in $available; do
+        if [[ "$v" == "$a" ]]; then
+          out="$out $v"
+          break
+        fi
+      done
+    done
+    out=$(echo "$out" | _trim)
+    if [[ -n "$out" ]]; then
+      sort_versions "$out"
+      return 0
+    fi
+  fi
+
+  return 1
+}
+
+# Determine which metadata file to use for extraction.
+# Precedence:
+#   1. pyproject.toml — if it yields a usable result
+#   2. setup.cfg — fallback for legacy setuptools/PBR projects
+# Prints the absolute or relative path on stdout (caller uses it) and
+# echoes a short tag on file descriptor 3 (or stderr if 3 is closed)
+# indicating which source was selected: 'pyproject', 'setup.cfg', or
+# 'none'. Returns 0 if at least one of the candidate files exists, or
+# 1 if neither is present.
+detect_metadata_source() {
+  local path_prefix="$1"
+  local py="${path_prefix%/}/pyproject.toml"
+  local cfg="${path_prefix%/}/setup.cfg"
+  if [[ -f "$py" ]]; then
+    echo "$py"
+    printf 'pyproject\n' 1>&2
+    return 0
+  fi
+  if [[ -f "$cfg" ]]; then
+    echo "$cfg"
+    printf 'setup.cfg\n' 1>&2
+    return 0
+  fi
+  printf 'none\n' 1>&2
   return 1
 }

--- a/lib/eol_utils.sh
+++ b/lib/eol_utils.sh
@@ -11,8 +11,11 @@
 # Return a static list of supported Python minor versions.
 # This is used as a fallback when network access or required tools are unavailable.
 get_static_python_versions() {
-  # Update periodically as new versions are released
-  echo "3.9 3.10 3.11 3.12 3.13 3.14"
+  # Update periodically as new versions are released.
+  # Python 3.9 reached end-of-life in October 2025 and is no longer
+  # included in the static list. Add new minor versions here as the
+  # upstream Python release train advances.
+  echo "3.10 3.11 3.12 3.13 3.14"
 }
 
 # Internal: check if a command exists in PATH.
@@ -33,9 +36,9 @@ _eol_curl_has_retry_all_errors() {
 # Behavior:
 # - Requires curl and jq. If either is missing, returns non-zero.
 # - Filters versions to include:
-#     - Python 3.9+ (3.9, 3.10, 3.11, ...)
+#     - Python 3.10+ (3.10, 3.11, 3.12, ...)
 #     - All 4.x+ minor series (future-proof)
-# - Sorts numerically by major.minor and prints as: "3.9 3.10 3.11 ..."
+# - Sorts numerically by major.minor and prints as: "3.10 3.11 3.12 ..."
 # - On any failure (network, invalid JSON, empty result), returns non-zero.
 fetch_eol_aware_versions() {
   local timeout="${1:-6}"
@@ -63,14 +66,17 @@ fetch_eol_aware_versions() {
   fi
 
   # Extract and filter cycles:
-  # - Include 3.9+ (3.9 through 3.99...)
+  # - Include 3.10+ (3.10 through 3.99...)
   # - Include 4.x+ (future major versions)
-  # Do not attempt to filter by EOL date here; tests only require excluding 3.8.
+  # 3.8 reached EOL on 2024-10-07 and 3.9 on 2025-10-31; neither is
+  # included in the modern matrix. Per-version EOL refinement is
+  # delegated to check_version_eol() so consumers can still opt in to
+  # warn/strip/fail handling.
   local versions
   versions="$(
     printf '%s\n' "$json" |
       jq -r '.[] | .cycle' |
-      grep -E '^(3\.(9|[1-9][0-9])|[4-9][0-9]*\.[0-9]+)$' |
+      grep -E '^(3\.(1[0-9]|[2-9][0-9])|[4-9][0-9]*\.[0-9]+)$' |
       sort -t. -k1,1n -k2,2n |
       tr '\n' ' ' | sed 's/ $//'
   )"

--- a/tests/README.md
+++ b/tests/README.md
@@ -108,7 +108,7 @@ Tests are automatically run via `.github/workflows/testing.yaml` which includes:
 
 ### EOL-Aware Features
 
-- ✅ **EOL version filtering** - Automatically excludes Python 3.8 and earlier
+- ✅ **EOL version filtering** - Automatically excludes Python 3.9 and earlier
 - ✅ **Dynamic version fetching** - Uses live data from official sources
 - ✅ **Network fallback mechanisms** - Works in air-gapped environments
 - ✅ **Static EOL data fallback** - Embedded EOL dates through 2029
@@ -123,8 +123,8 @@ Tests are automatically run via `.github/workflows/testing.yaml` which includes:
 
 ### EOL-Aware Version Support
 
-- **Excluded**: Python 3.8 and earlier (End-of-Life)
-- **Included**: Python 3.9, 3.10, 3.11, 3.12, 3.13, 3.14 (supported)
+- **Excluded**: Python 3.9 and earlier (End-of-Life)
+- **Included**: Python 3.10, 3.11, 3.12, 3.13, 3.14 (supported)
 
 ### Sample Outputs
 

--- a/tests/fixtures/setup_cfg_classifiers_only.cfg
+++ b/tests/fixtures/setup_cfg_classifiers_only.cfg
@@ -1,0 +1,22 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg classifiers fallback (no python_requires)
+# TEST_TYPE: setup-cfg-classifiers-only
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.11
+# EXPECTED_VERSIONS_COUNT: 3
+# DESCRIPTION: Modern setuptools setup.cfg with classifiers but no python_requires
+
+[metadata]
+name = test-setup-cfg-classifiers
+version = 1.0.0
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13

--- a/tests/fixtures/setup_cfg_exact_constraint.cfg
+++ b/tests/fixtures/setup_cfg_exact_constraint.cfg
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg exact pin (==3.12)
+# TEST_TYPE: setup-cfg-exact-constraint
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.12
+# EXPECTED_VERSIONS_COUNT: 1
+# DESCRIPTION: Exact-pin python_requires expressed in setup.cfg
+
+[metadata]
+name = test-setup-cfg-exact
+version = 1.0.0
+
+[options]
+python_requires = "==3.12"

--- a/tests/fixtures/setup_cfg_no_python_info.cfg
+++ b/tests/fixtures/setup_cfg_no_python_info.cfg
@@ -1,0 +1,20 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg with no Python metadata (should fail)
+# TEST_TYPE: setup-cfg-no-python-info
+# SHOULD_FAIL: true
+# DESCRIPTION: setup.cfg present but devoid of any Python version metadata
+#   (no python_requires, no Python classifiers); should error out.
+
+[metadata]
+name = test-setup-cfg-empty
+version = 1.0.0
+description = No Python metadata at all
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent
+
+[options]
+zip_safe = False

--- a/tests/fixtures/setup_cfg_pbr_legacy.cfg
+++ b/tests/fixtures/setup_cfg_pbr_legacy.cfg
@@ -1,0 +1,31 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg legacy PBR 'classifier' (singular)
+# TEST_TYPE: setup-cfg-pbr-style
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.10
+# EXPECTED_VERSIONS_COUNT: 5
+# DESCRIPTION: PBR/distutils-style setup.cfg using the singular 'classifier' key
+
+[metadata]
+name = lfdocs_conf
+author = Linux Foundation Releng
+license = EPL-1.0
+classifier =
+    Intended Audience :: Developers
+    Intended Audience :: Information Technology
+    License :: OSI Approved :: Eclipse Public License 1.0 (EPL-1.0)
+    Operating System :: OS Independent
+    Programming Language :: Python
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+    Programming Language :: Python :: 3.14
+
+[options]
+python_requires = >=3.10

--- a/tests/fixtures/setup_cfg_range_constraint.cfg
+++ b/tests/fixtures/setup_cfg_range_constraint.cfg
@@ -1,0 +1,17 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg range constraint (>=3.11,<3.13)
+# TEST_TYPE: setup-cfg-range-constraint
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.11
+# EXPECTED_VERSIONS_COUNT: 2
+# DESCRIPTION: Comma-joined range constraint exercised via setup.cfg
+
+[metadata]
+name = test-setup-cfg-range
+version = 1.0.0
+
+[options]
+python_requires = >=3.11,<3.13

--- a/tests/fixtures/setup_cfg_requires_python_basic.cfg
+++ b/tests/fixtures/setup_cfg_requires_python_basic.cfg
@@ -1,0 +1,19 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: 2025 The Linux Foundation
+
+# TEST_METADATA:
+# TEST_NAME: setup.cfg basic python_requires (>=3.10)
+# TEST_TYPE: setup-cfg-requires-python
+# SHOULD_FAIL: false
+# EXPECTED_MIN_VERSION: 3.10
+# EXPECTED_VERSIONS_COUNT: 5
+# DESCRIPTION: Modern setuptools setup.cfg with quoted python_requires only
+
+[metadata]
+name = test-setup-cfg-basic
+version = 1.0.0
+description = Basic setup.cfg python_requires test
+license = Apache-2.0
+
+[options]
+python_requires = ">=3.10"

--- a/tests/scripts/test_all.sh
+++ b/tests/scripts/test_all.sh
@@ -43,6 +43,9 @@ cleanup() {
     if [ -f "$TESTS_DIR/pyproject.toml" ]; then
         rm -f "$TESTS_DIR/pyproject.toml"
     fi
+    if [ -f "$TESTS_DIR/setup.cfg" ]; then
+        rm -f "$TESTS_DIR/setup.cfg"
+    fi
     # Clean up any temporary files
     find "$TESTS_DIR" -name "*.tmp" -delete 2>/dev/null || true
 }
@@ -153,8 +156,10 @@ test_fixture_with_action() {
     # Change to test directory
     pushd "$test_dir" >/dev/null 2>&1
 
-    # Simulate the action's core logic using shared utilities
-    local ALL_SUPPORTED_VERSIONS="3.9 3.10 3.11 3.12 3.13 3.14"
+    # Simulate the action's core logic using shared utilities.
+    # 3.9 is intentionally absent: it reached EOL in October 2025
+    # and is no longer part of the default supported set.
+    local ALL_SUPPORTED_VERSIONS="3.10 3.11 3.12 3.13 3.14"
     local PYTHON_VERSIONS=""
 
     # Use shared utility to process Python constraints
@@ -261,6 +266,172 @@ PYTHON_VERSIONS=$PYTHON_VERSIONS"
     echo ""
 }
 
+# Variant of test_fixture_with_action that exercises the setup.cfg path.
+# The fixture is copied to <tmpdir>/setup.cfg (NOT pyproject.toml) so the
+# action consults the setup.cfg branch.
+test_setup_cfg_fixture() {
+    local fixture_file="$1"
+    local fixture_name
+    fixture_name=$(basename "$fixture_file" .cfg)
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+
+    local test_name
+    test_name=$(extract_metadata "$fixture_file" "TEST_NAME")
+    local should_fail
+    should_fail=$(extract_metadata "$fixture_file" "SHOULD_FAIL")
+    local description
+    description=$(extract_metadata "$fixture_file" "DESCRIPTION")
+
+    if [ -z "$test_name" ]; then
+        test_name="$fixture_name"
+    fi
+
+    log_test_start "$test_name"
+    if [ -n "$description" ]; then
+        echo "   Description: $description"
+    fi
+
+    local test_dir
+    test_dir=$(mktemp -d)
+    cp "$fixture_file" "$test_dir/setup.cfg"
+
+    local result=""
+    local exit_code=0
+
+    pushd "$test_dir" >/dev/null 2>&1
+
+    local ALL_SUPPORTED_VERSIONS="3.10 3.11 3.12 3.13 3.14"
+    local PYTHON_VERSIONS=""
+
+    if PYTHON_VERSIONS=$(process_python_constraints_setup_cfg "setup.cfg" \
+                         "$ALL_SUPPORTED_VERSIONS"); then
+        local BUILD_PYTHON MATRIX_JSON
+        BUILD_PYTHON=$(get_build_version "$PYTHON_VERSIONS")
+        MATRIX_JSON=$(generate_matrix_json "$PYTHON_VERSIONS")
+        result="STATUS=SUCCESS
+BUILD_PYTHON=$BUILD_PYTHON
+MATRIX_JSON=$MATRIX_JSON
+PYTHON_VERSIONS=$PYTHON_VERSIONS"
+        exit_code=0
+    else
+        exit_code=1
+        result="No Python versions found"
+    fi
+
+    popd >/dev/null 2>&1
+    rm -rf "$test_dir"
+
+    local test_passed=true
+    if [ "$should_fail" = "true" ]; then
+        if [ $exit_code -eq 0 ]; then
+            log_error "$test_name - Expected test to fail but it succeeded"
+            test_passed=false
+        else
+            log_success "$test_name - Correctly failed as expected"
+        fi
+    else
+        if [ $exit_code -ne 0 ]; then
+            log_error "$test_name - Expected test to succeed but it failed: $result"
+            test_passed=false
+        else
+            local build_python python_versions
+            build_python=$(echo "$result" | grep "^BUILD_PYTHON=" | cut -d'=' -f2-)
+            python_versions=$(echo "$result" | grep "^PYTHON_VERSIONS=" | cut -d'=' -f2-)
+            log_success "$test_name"
+            echo "   Build Python: $build_python"
+            echo "   All versions: $python_versions"
+
+            local expected_exact expected_min expected_count
+            expected_exact=$(extract_metadata "$fixture_file" "EXPECTED_EXACT_VERSION")
+            expected_min=$(extract_metadata "$fixture_file" "EXPECTED_MIN_VERSION")
+            expected_count=$(extract_metadata "$fixture_file" "EXPECTED_VERSIONS_COUNT")
+
+            if [ -n "$expected_exact" ]; then
+                if ! assert_equal "Exact version" "$expected_exact" "$python_versions"; then
+                    test_passed=false
+                fi
+                if ! assert_equal "Build version" "$expected_exact" "$build_python"; then
+                    test_passed=false
+                fi
+            fi
+            if [ -n "$expected_min" ]; then
+                local actual_min
+                actual_min=$(first_version "$python_versions")
+                if ! assert_equal "Minimum version" "$expected_min" "$actual_min"; then
+                    test_passed=false
+                fi
+            fi
+            if [ -n "$expected_count" ]; then
+                local actual_count
+                actual_count=$(count_versions "$python_versions")
+                if ! assert_equal "Versions count" "$expected_count" "$actual_count"; then
+                    test_passed=false
+                fi
+            fi
+        fi
+    fi
+
+    if [ "$test_passed" = true ]; then
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+    echo ""
+}
+
+# Detect the metadata source precedence using the shared helper.
+test_metadata_source_precedence() {
+    log_section "Metadata Source Precedence"
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log_test_start "detect_metadata_source: pyproject takes precedence"
+
+    local d
+    d=$(mktemp -d)
+    printf '[project]\nname = "x"\nrequires-python = ">=3.11"\n' > "$d/pyproject.toml"
+    printf '[metadata]\nname = x\n' > "$d/setup.cfg"
+    local source_path source_tag
+    source_path=$(detect_metadata_source "$d" 2> /tmp/_src_tag) || true
+    source_tag=$(cat /tmp/_src_tag)
+    if [ "$(basename "$source_path")" = "pyproject.toml" ] && [ "$source_tag" = "pyproject" ]; then
+        log_success "pyproject.toml wins when both files exist"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        log_error "Expected pyproject.toml precedence; got path='$source_path' tag='$source_tag'"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+    rm -rf "$d" /tmp/_src_tag
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log_test_start "detect_metadata_source: setup.cfg used when pyproject absent"
+    d=$(mktemp -d)
+    printf '[metadata]\nname = x\n' > "$d/setup.cfg"
+    source_path=$(detect_metadata_source "$d" 2> /tmp/_src_tag) || true
+    source_tag=$(cat /tmp/_src_tag)
+    if [ "$(basename "$source_path")" = "setup.cfg" ] && [ "$source_tag" = "setup.cfg" ]; then
+        log_success "setup.cfg used when pyproject.toml absent"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    else
+        log_error "Expected setup.cfg detection; got path='$source_path' tag='$source_tag'"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    fi
+    rm -rf "$d" /tmp/_src_tag
+
+    TOTAL_TESTS=$((TOTAL_TESTS + 1))
+    log_test_start "detect_metadata_source: error when neither file exists"
+    d=$(mktemp -d)
+    if detect_metadata_source "$d" 2>/dev/null; then
+        log_error "Expected non-zero when neither file exists"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+    else
+        log_success "Correctly returned non-zero when neither file exists"
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+    fi
+    rm -rf "$d"
+    echo ""
+}
+
 # Function to test EOL awareness
 test_eol_awareness() {
     log_section "EOL Awareness Tests"
@@ -268,26 +439,34 @@ test_eol_awareness() {
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
     log_test_start "EOL Version Filtering"
 
-    # Test that our static version list excludes EOL versions
-    local supported_versions="3.9 3.10 3.11 3.12 3.13 3.14"
+    # Test that our static version list excludes EOL versions.
+    # 3.9 reached EOL in October 2025 and 3.8 in October 2024; both
+    # should be absent from the static list.
+    local supported_versions
+    supported_versions=$(get_static_python_versions)
 
     echo "   Test versions: $supported_versions"
 
-    # Check that Python 3.8 is not included (EOL October 7, 2024)
-    if echo "$supported_versions" | grep -q "3.8"; then
-        log_error "Python 3.8 should be EOL but was included in test versions"
+    if echo "$supported_versions" | grep -qE '(^| )3\.8( |$)'; then
+        log_error "Python 3.8 should be EOL but was included in static versions"
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        return
+    fi
+    if echo "$supported_versions" | grep -qE '(^| )3\.9( |$)'; then
+        log_error "Python 3.9 should be EOL but was included in static versions"
         FAILED_TESTS=$((FAILED_TESTS + 1))
         return
     fi
 
-    # Check that we have reasonable versions (3.9+)
-    if ! echo "$supported_versions" | grep -q "3.9"; then
-        log_error "Expected to find Python 3.9 in supported versions"
+    # Sanity-check: 3.10 must be present (oldest non-EOL minor at the
+    # time of writing). Update when 3.10 itself reaches EOL.
+    if ! echo "$supported_versions" | grep -qE '(^| )3\.10( |$)'; then
+        log_error "Expected to find Python 3.10 in supported versions"
         FAILED_TESTS=$((FAILED_TESTS + 1))
         return
     fi
 
-    log_success "EOL Version Filtering - Python 3.8 correctly excluded"
+    log_success "EOL Version Filtering - Python 3.8 and 3.9 correctly excluded"
     PASSED_TESTS=$((PASSED_TESTS + 1))
     echo ""
 }
@@ -299,10 +478,10 @@ test_network_fallback() {
     TOTAL_TESTS=$((TOTAL_TESTS + 1))
     log_test_start "Static Fallback Mechanism"
 
-    # Verify static fallback works
-    local static_versions="3.9 3.10 3.11 3.12 3.13 3.14"
+    local static_versions
+    static_versions=$(get_static_python_versions)
 
-    if [ -n "$static_versions" ] && echo "$static_versions" | grep -q "3.9"; then
+    if [ -n "$static_versions" ] && echo "$static_versions" | grep -qE '(^| )3\.10( |$)'; then
         log_success "Static Fallback - Versions available when network unavailable"
         echo "   Static versions: $static_versions"
         PASSED_TESTS=$((PASSED_TESTS + 1))
@@ -346,21 +525,21 @@ test_eol_api_logic() {
             return
         fi
 
-        # Check for minimum expected versions (3.9+)
-        if echo "$versions" | grep -q "3.9" && echo "$versions" | grep -q "3.1[0-9]"; then
-            log_success "Found expected minimum versions (3.9+)"
+        # Check for minimum expected versions (3.10+; 3.9 is now EOL)
+        if echo "$versions" | grep -qE '(^| )3\.10( |$)'; then
+            log_success "Found expected minimum version (3.10)"
         else
             log_warning "Expected versions not found"
-            echo "   Expected to find 3.9 and 3.1x versions"
+            echo "   Expected to find 3.10 in returned versions"
         fi
 
-        # Check that EOL versions are excluded (Python 3.8)
-        if echo "$versions" | grep -q "3.8"; then
-            log_error "Python 3.8 should be EOL but was included"
+        # Check that EOL versions are excluded (Python 3.8 and 3.9)
+        if echo "$versions" | grep -qE '(^| )3\.[89]( |$)'; then
+            log_error "EOL Python (3.8/3.9) should not be in API result"
             FAILED_TESTS=$((FAILED_TESTS + 1))
             return
         else
-            log_success "Python 3.8 correctly excluded (EOL)"
+            log_success "EOL Python versions correctly excluded"
         fi
 
         PASSED_TESTS=$((PASSED_TESTS + 1))
@@ -432,19 +611,34 @@ main() {
 
     local fixture_count
     fixture_count=$(find "$FIXTURES_DIR" -name "*.toml" 2>/dev/null | wc -l)
-    log_info "Found $fixture_count test fixtures"
+    local cfg_fixture_count
+    cfg_fixture_count=$(find "$FIXTURES_DIR" -name "*.cfg" 2>/dev/null | wc -l)
+    log_info "Found $fixture_count pyproject.toml test fixtures"
+    log_info "Found $cfg_fixture_count setup.cfg test fixtures"
 
     # Run unit tests first
     run_unit_tests
 
     # Test fixture files
-    log_section "Fixture-Based Tests"
+    log_section "pyproject.toml Fixture-Based Tests"
 
     for fixture_file in "$FIXTURES_DIR"/*.toml; do
         if [ -f "$fixture_file" ]; then
             test_fixture_with_action "$fixture_file"
         fi
     done
+
+    # Test setup.cfg fixtures (new path: legacy setuptools / PBR projects)
+    log_section "setup.cfg Fixture-Based Tests"
+
+    for fixture_file in "$FIXTURES_DIR"/*.cfg; do
+        if [ -f "$fixture_file" ]; then
+            test_setup_cfg_fixture "$fixture_file"
+        fi
+    done
+
+    # Test metadata source precedence detection
+    test_metadata_source_precedence
 
     # Test EOL awareness
     test_eol_awareness
@@ -473,6 +667,9 @@ main() {
         echo "   • Exact version constraints ✅"
         echo "   • Classifiers-only scenarios ✅"
         echo "   • Mixed version scenarios ✅"
+        echo "   • setup.cfg python_requires extraction ✅"
+        echo "   • setup.cfg classifiers (modern + PBR legacy) ✅"
+        echo "   • Metadata source precedence (pyproject > setup.cfg) ✅"
         echo "   • Error handling and edge cases ✅"
         echo "   • EOL-aware version filtering ✅"
         echo "   • Network fallback mechanisms ✅"

--- a/tests/scripts/unit/test_constraint_utils.sh
+++ b/tests/scripts/unit/test_constraint_utils.sh
@@ -451,6 +451,248 @@ python = "^3.10"')
     rm -f "$test_file"
 }
 
+# Helper: create a temporary setup.cfg fixture and echo its path.
+create_setup_cfg() {
+    local content="$1"
+    local d
+    d=$(mktemp -d)
+    printf '%s\n' "$content" > "$d/setup.cfg"
+    echo "$d/setup.cfg"
+}
+
+# Test extract_requires_python_setup_cfg
+test_extract_requires_python_setup_cfg() {
+    log_section "Testing extract_requires_python_setup_cfg"
+
+    log_test_start "Bare value (no quotes)"
+    local f
+    f=$(create_setup_cfg '[options]
+python_requires = >=3.10')
+    test_output "Bare >=3.10" \
+        "extract_requires_python_setup_cfg '$f'" \
+        ">=3.10"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Double-quoted value"
+    f=$(create_setup_cfg '[options]
+python_requires = ">=3.11"')
+    test_output 'Quoted ">=3.11"' \
+        "extract_requires_python_setup_cfg '$f'" \
+        ">=3.11"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Single-quoted value"
+    f=$(create_setup_cfg "[options]
+python_requires = '==3.12'")
+    test_output "Single-quoted ==3.12" \
+        "extract_requires_python_setup_cfg '$f'" \
+        "==3.12"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Comma-joined range constraint"
+    f=$(create_setup_cfg '[options]
+python_requires = >=3.11,<3.13')
+    test_output "Range >=3.11,<3.13" \
+        "extract_requires_python_setup_cfg '$f'" \
+        ">=3.11,<3.13"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Key absent"
+    f=$(create_setup_cfg '[metadata]
+name = empty')
+    run_test "Missing python_requires should fail" \
+        "extract_requires_python_setup_cfg '$f'" \
+        1
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Key present but outside [options]"
+    f=$(create_setup_cfg '[metadata]
+python_requires = >=3.10
+[options]
+zip_safe = False')
+    run_test "python_requires under [metadata] should not match" \
+        "extract_requires_python_setup_cfg '$f'" \
+        1
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Comment-only file"
+    f=$(create_setup_cfg '# nothing to see here')
+    run_test "No [options] section should fail" \
+        "extract_requires_python_setup_cfg '$f'" \
+        1
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Missing file"
+    run_test "Nonexistent file should fail" \
+        "extract_requires_python_setup_cfg '/nonexistent/setup.cfg'" \
+        1
+}
+
+# Test extract_classifiers_setup_cfg (modern 'classifiers' + legacy 'classifier')
+test_extract_classifiers_setup_cfg() {
+    log_section "Testing extract_classifiers_setup_cfg"
+
+    log_test_start "Modern setuptools 'classifiers'"
+    local f
+    f=$(create_setup_cfg '[metadata]
+name = x
+classifiers =
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12')
+    test_output "Modern classifiers" \
+        "extract_classifiers_setup_cfg '$f'" \
+        "3.10 3.11 3.12"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Legacy PBR 'classifier' (singular)"
+    f=$(create_setup_cfg '[metadata]
+name = legacy
+classifier =
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13')
+    test_output "Legacy classifier" \
+        "extract_classifiers_setup_cfg '$f'" \
+        "3.11 3.12 3.13"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Both keys present, results merged in first-seen order"
+    f=$(create_setup_cfg '[metadata]
+name = both
+classifiers =
+    Programming Language :: Python :: 3.12
+    Programming Language :: Python :: 3.13
+classifier =
+    Programming Language :: Python :: 3.11')
+    test_output "Merged keys" \
+        "extract_classifiers_setup_cfg '$f'" \
+        "3.12 3.13 3.11"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "No Python classifiers present"
+    f=$(create_setup_cfg '[metadata]
+name = nopython
+classifiers =
+    License :: OSI Approved :: Apache Software License
+    Operating System :: OS Independent')
+    run_test "Should fail without Python :: X.Y lines" \
+        "extract_classifiers_setup_cfg '$f'" \
+        1
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Wildcard X.Y.* classifiers ignored"
+    # '3.10.*' must NOT be matched as a minor version. The negative
+    # lookahead in the Python helper guards against this.
+    f=$(create_setup_cfg '[metadata]
+name = wildcard
+classifiers =
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.10.*')
+    test_output "Wildcard ignored" \
+        "extract_classifiers_setup_cfg '$f'" \
+        "3.10"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Missing file"
+    run_test "Nonexistent file should fail" \
+        "extract_classifiers_setup_cfg '/nonexistent/setup.cfg'" \
+        1
+}
+
+# Test process_python_constraints_setup_cfg high-level wrapper.
+test_process_python_constraints_setup_cfg() {
+    log_section "Testing process_python_constraints_setup_cfg"
+
+    local available_versions="3.10 3.11 3.12 3.13 3.14"
+
+    log_test_start "python_requires path"
+    local f
+    f=$(create_setup_cfg '[options]
+python_requires = >=3.12')
+    test_output "python_requires >=3.12" \
+        "process_python_constraints_setup_cfg '$f' '$available_versions'" \
+        "3.12 3.13 3.14"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Classifiers fallback path"
+    f=$(create_setup_cfg '[metadata]
+name = cls
+classifiers =
+    Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12')
+    test_output "Classifiers-only setup.cfg" \
+        "process_python_constraints_setup_cfg '$f' '$available_versions'" \
+        "3.11 3.12"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Classifiers with unavailable versions are filtered"
+    f=$(create_setup_cfg '[metadata]
+name = filter
+classifiers =
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.12')
+    test_output "Only 3.12 remains after filter" \
+        "process_python_constraints_setup_cfg '$f' '$available_versions'" \
+        "3.12"
+    rm -rf "$(dirname "$f")"
+
+    log_test_start "Empty metadata file (should fail)"
+    f=$(create_setup_cfg '[metadata]
+name = empty')
+    run_test "No usable metadata should fail" \
+        "process_python_constraints_setup_cfg '$f' '$available_versions'" \
+        1
+    rm -rf "$(dirname "$f")"
+}
+
+# Test detect_metadata_source precedence helper.
+test_detect_metadata_source() {
+    log_section "Testing detect_metadata_source"
+
+    log_test_start "pyproject.toml wins over setup.cfg"
+    local d
+    d=$(mktemp -d)
+    printf '[project]\nname = "x"\n' > "$d/pyproject.toml"
+    printf '[metadata]\nname = x\n' > "$d/setup.cfg"
+    test_output "Returns pyproject.toml path" \
+        "detect_metadata_source '$d' 2>/dev/null" \
+        "$d/pyproject.toml"
+    rm -rf "$d"
+
+    log_test_start "setup.cfg used when pyproject.toml absent"
+    d=$(mktemp -d)
+    printf '[metadata]\nname = x\n' > "$d/setup.cfg"
+    test_output "Returns setup.cfg path" \
+        "detect_metadata_source '$d' 2>/dev/null" \
+        "$d/setup.cfg"
+    rm -rf "$d"
+
+    log_test_start "Returns non-zero when neither file exists"
+    d=$(mktemp -d)
+    run_test "Should fail when no metadata files exist" \
+        "detect_metadata_source '$d'" \
+        1
+    rm -rf "$d"
+
+    log_test_start "Source tag is written to stderr"
+    d=$(mktemp -d)
+    printf '[project]\nname = "x"\n' > "$d/pyproject.toml"
+    local tag
+    tag=$(detect_metadata_source "$d" 2>&1 >/dev/null)
+    if [[ "$tag" == "pyproject" ]]; then
+        TOTAL_TESTS=$((TOTAL_TESTS + 1))
+        PASSED_TESTS=$((PASSED_TESTS + 1))
+        log_success "stderr tag = 'pyproject'"
+    else
+        TOTAL_TESTS=$((TOTAL_TESTS + 1))
+        FAILED_TESTS=$((FAILED_TESTS + 1))
+        log_error "Expected stderr tag 'pyproject', got '$tag'"
+    fi
+    rm -rf "$d"
+}
+
 # Main test execution
 main() {
     echo -e "${CYAN}"
@@ -468,6 +710,10 @@ main() {
     test_validate_json_format
     test_get_build_version
     test_process_python_constraints
+    test_extract_requires_python_setup_cfg
+    test_extract_classifiers_setup_cfg
+    test_process_python_constraints_setup_cfg
+    test_detect_metadata_source
 
     # Final summary
     log_section "Unit Test Results Summary"
@@ -491,6 +737,10 @@ main() {
         echo "   • validate_json_format ✅"
         echo "   • get_build_version ✅"
         echo "   • process_python_constraints ✅"
+        echo "   • extract_requires_python_setup_cfg ✅"
+        echo "   • extract_classifiers_setup_cfg ✅"
+        echo "   • process_python_constraints_setup_cfg ✅"
+        echo "   • detect_metadata_source ✅"
         echo ""
         exit 0
     else


### PR DESCRIPTION
## Summary

Extends the action to accept **`setup.cfg`** as a project metadata source alongside `pyproject.toml`. The action previously hard-errored the moment `pyproject.toml` was absent, which made it unusable for legacy declarative-setuptools / PBR projects (still common in OpenStack and several LF Releng repos). This PR closes that gap and also refreshes the EOL defaults so the action no longer ships Python 3.9 in its fallback matrix.

## Why

We are working towards consolidating Python-version extraction inside [`python-build-action`](https://github.com/lfreleng-actions/python-build-action) by having it call this action instead of carrying its own duplicate parsing logic. The setup.cfg gap was the single biggest blocker — `python-build-action` already supports setup.cfg via `build-metadata-action`, so this action must do the same before it can become the canonical extractor.

## Source precedence

| Layout | Behaviour |
| --- | --- |
| `pyproject.toml` only | Existing behaviour, unchanged. `metadata_source = pyproject.toml`. |
| `setup.cfg` only | **New.** Action reads `[options] python_requires` and `[metadata] classifiers`/`classifier`. `metadata_source = setup.cfg`. |
| Both present | `pyproject.toml` wins. `setup.cfg` is consulted only when `pyproject.toml` yields no Python metadata. |
| Neither present | Action errors with a clear message naming both expected files. |

## New output

- **`metadata_source`** — either `pyproject.toml` or `setup.cfg`, so downstream actions can branch on the source of truth without re-detecting.

## Implementation highlights

- `extract_requires_python_setup_cfg()` and `extract_classifiers_setup_cfg()` in both `action.yaml` and `lib/constraint_utils.sh`. The Python (`configparser`) path is preferred; an awk/grep fallback covers runners without `python3`.
- Modern `classifiers` and legacy PBR `classifier` (singular) keys under `[metadata]` are both honoured and combined in first-seen order.
- `detect_metadata_source()` helper centralises the precedence rule and is exercised directly by the new unit and integration tests.
- **Bug fix**: classifier-extraction regex no longer back-tracks. Previously `Programming Language :: Python :: 3.10.*` could spuriously match as `3.1` because the negative lookahead only rejected `.*`. The lookahead now rejects both `.` and a trailing digit.
- **Bug fix**: `pyproject.toml` classifier dedup switched from `sort -u` (which lexicographically places `3.10` before `3.9`) to `awk '!seen[$0]++'` for stable, source-order output.

## Companion EOL refresh

Bundled into the same commit because the changes are entangled at file level:

- `INTERNAL_SUPPORTED_VERSIONS` (action.yaml), `get_static_python_versions()` (lib/eol_utils.sh), and the `fetch_eol_aware_versions()` cycle-filter regex now start at **3.10**. Python 3.9 reached EOL on 2025-10-31.
- `README.md`, `tests/README.md` and example outputs updated to the `3.10 -> 3.14` range.

## Test coverage added

- **Six setup.cfg fixtures** under `tests/fixtures/`: modern `python_requires`, classifiers-only, PBR legacy `classifier`, range constraint, exact pin, no-python-info (should-fail).
- **Integration tests** in `tests/scripts/test_all.sh`: `test_setup_cfg_fixture()` loop plus a metadata-source precedence test exercising both files in the same workspace.
- **Unit tests** in `tests/scripts/unit/test_constraint_utils.sh`: twenty new cases covering each new helper, the regex backtracking edge case, mixed-keys merging, and `detect_metadata_source()` precedence.
- **Two new CI jobs** in `.github/workflows/testing.yaml`:
  - `test-setup-cfg-fixtures` — matrix over all six fixtures, asserts `metadata_source = 'setup.cfg'` for the success cases.
  - `test-metadata-source-precedence` — places both files in one directory with conflicting constraints; asserts `pyproject.toml` wins and `setup.cfg` values do not leak.
- `.gitignore` exception for `tests/fixtures/setup_cfg_*.cfg` so the generic `*.cfg` ignore does not swallow the fixtures.

## Verification

```text
$ bash tests/scripts/test_all.sh
...
📊 Test Statistics:
   Total Tests: 26
   Passed: 26
   Failed: 0

$ bash tests/scripts/unit/test_constraint_utils.sh
...
📊 Test Statistics:
   Total Tests: 61
   Passed: 61
   Failed: 0
```

Pre-commit (yamllint, markdownlint, shellcheck, write-good, actionlint, codespell, reuse-lint, gitlint) all pass.

## Readiness for incorporation into `python-build-action`

This PR closes the main blocker (`setup.cfg` support) and addresses several correctness issues from an internal audit. Two smaller items remain before `python-build-action` can drop `build-metadata-action` and call this action directly:

1. **`setup.py` static `python_requires` extraction** — rare but legitimate; can land as a follow-up.
2. **A soft-fail / `fallback_version` input** so the action can return a sensible default instead of `exit 1` when constraints are absent. `python-build-action` currently surfaces a friendly warning and falls back to a default; the same contract would need to be supported here for parity. Tracking as a follow-up issue.

Happy to break those out into separate PRs once this lands.