### PR TITLE
Fix: resolve zizmor auditor persona findings

### DIFF
--- a/.github/workflows/release-drafter.yaml
+++ b/.github/workflows/release-drafter.yaml
@@ -20,16 +20,26 @@ jobs:
   update_release_draft:
     name: 'Update Release Draft'
     permissions:
-      # write permission is required to create releases
-      contents: write
+      contents: write  # Create and update draft releases
     runs-on: 'ubuntu-latest'
     timeout-minutes: 3
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: 'audit'
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
-      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+      - uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e  # v7.5.1

--- a/.github/workflows/tag-push.yaml
+++ b/.github/workflows/tag-push.yaml
@@ -13,6 +13,13 @@ on:
 
 permissions: {}
 
+# Serialise repeated runs for the same tag; never cancel an in-flight
+# release promotion. Distinct tags use distinct groups and proceed
+# independently.
+concurrency:
+  group: '${{ github.workflow }}-${{ github.ref }}'
+  cancel-in-progress: false
+
 jobs:
   validate_tag:
     name: 'Validate Tag'
@@ -25,11 +32,22 @@ jobs:
     outputs:
       tag: "${{ steps.tag_validate.outputs.tag_name }}"
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
@@ -53,14 +71,25 @@ jobs:
     needs: validate_tag
     runs-on: 'ubuntu-latest'
     permissions:
-      contents: write
+      contents: write  # Promote (publish) the draft release for the tag
     timeout-minutes: 5
     steps:
-      # Harden the runner used by this workflow
+      # Load the egress allow-list out-of-band from the
+      # organisation's .github repository and publish it as
+      # $CONNECTION_ALLOW_LIST for the harden-runner step below.
       # yamllint disable-line rule:line-length
-      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+      - uses: lfreleng-actions/harden-runner-block-action@6db537b3e6d060c3287c5a3ce2c28b55b0af330d  # v0.2.1
         with:
-          egress-policy: audit
+          config: '@18d9c4446bea555d0783e850f6d295f844fe8f67'  # v0.1.1
+
+      # Harden the runner with the just-loaded allow-list.
+      - name: 'Harden runner (block)'
+        # yamllint disable-line rule:line-length
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411  # v2.19.4
+        with:
+          egress-policy: 'block'
+          allowed-endpoints: >
+            ${{ env.CONNECTION_ALLOW_LIST }}
 
       # yamllint disable-line rule:line-length
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0

--- a/.github/workflows/testing.yaml
+++ b/.github/workflows/testing.yaml
@@ -20,6 +20,10 @@ on:
 
 permissions: {}
 
+concurrency:
+  group: "${{ github.workflow }}-${{ github.ref }}"
+  cancel-in-progress: true
+
 jobs:
   ### Comprehensive Test Suite (All Fixtures) ###
   test-comprehensive:
@@ -37,6 +41,8 @@ jobs:
 
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Run comprehensive test suite'
         run: |
@@ -53,12 +59,15 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Checkout sample project repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           repository: 'lfreleng-actions/test-python-project'
           path: 'test-python-project'
+          persist-credentials: false
 
       # yamllint disable rule:line-length
 
@@ -172,6 +181,8 @@ jobs:
       - name: 'Checkout repository'
         # yamllint disable-line rule:line-length
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Create empty test directory'
         run: mkdir -p empty-test-dir
@@ -247,13 +258,18 @@ jobs:
     steps:
       - name: 'Checkout repository'
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          persist-credentials: false
 
       - name: 'Prepare fixture workspace'
+        env:
+          FIXTURE_NAME: ${{ matrix.name }}
+          FIXTURE_FILE: ${{ matrix.file }}
         run: |
           set -euo pipefail
-          workdir="poetry-fixture-${{ matrix.name }}"
+          workdir="poetry-fixture-$FIXTURE_NAME"
           mkdir -p "$workdir"
-          cp "${{ matrix.file }}" "$workdir/pyproject.toml"
+          cp "$FIXTURE_FILE" "$workdir/pyproject.toml"
           echo "WORKDIR=$workdir" >> "$GITHUB_ENV"
 
       - name: 'Run action on Poetry fixture (offline)'
@@ -264,26 +280,33 @@ jobs:
           offline_mode: 'true'
 
       - name: 'Assert outputs for Poetry fixture'
+        env:
+          FIXTURE_NAME: ${{ matrix.name }}
+          EXPECTED_BUILD: ${{ matrix.expected_build }}
+          EXPECTED_VERSIONS: ${{ matrix.expected_versions }}
+          SUPPORTED_VERSIONS: ${{ steps.run.outputs.supported_versions }}
+          BUILD_PYTHON: ${{ steps.run.outputs.build_python }}
+          MATRIX_JSON: ${{ steps.run.outputs.matrix_json }}
         # yamllint disable rule:line-length
         run: |
-          echo "Supported versions: '${{ steps.run.outputs.supported_versions }}'"
-          echo "Build Python: '${{ steps.run.outputs.build_python }}'"
+          echo "Supported versions: '$SUPPORTED_VERSIONS'"
+          echo "Build Python: '$BUILD_PYTHON'"
 
           # Use the raw matrix_json output and compact it with jq for consistent comparison
-          actual_json=$(echo '${{ steps.run.outputs.matrix_json }}' | jq -c .)
+          actual_json=$(printf '%s' "$MATRIX_JSON" | jq -c .)
           echo "Matrix JSON: '$actual_json'"
 
-          if [ "${{ steps.run.outputs.build_python }}" != "${{ matrix.expected_build }}" ]; then
-            echo "Error: build_python mismatch (expected '${{ matrix.expected_build }}')"
+          if [ "$BUILD_PYTHON" != "$EXPECTED_BUILD" ]; then
+            echo "Error: build_python mismatch (expected '$EXPECTED_BUILD')"
             exit 1
           fi
-          if [ "${{ steps.run.outputs.supported_versions }}" != "${{ matrix.expected_versions }}" ]; then
-            echo "Error: supported_versions mismatch (expected '${{ matrix.expected_versions }}')"
+          if [ "$SUPPORTED_VERSIONS" != "$EXPECTED_VERSIONS" ]; then
+            echo "Error: supported_versions mismatch (expected '$EXPECTED_VERSIONS')"
             exit 1
           fi
 
           # Construct expected JSON using jq to ensure formatting matches
-          expected_json=$(printf '%s\n' "${{ matrix.expected_versions }}" | tr ' ' '\n' | jq -R . | jq -s -c '{"python-version": .}')
+          expected_json=$(printf '%s\n' "$EXPECTED_VERSIONS" | tr ' ' '\n' | jq -R . | jq -s -c '{"python-version": .}')
 
           if [ "$expected_json" != "$actual_json" ]; then
             echo "Error: matrix_json mismatch"
@@ -291,4 +314,4 @@ jobs:
             echo "Actual:   $actual_json"
             exit 1
           fi
-          echo "Poetry fixture '${{ matrix.name }}' passed ✅"
+          echo "Poetry fixture '$FIXTURE_NAME' passed ✅"


### PR DESCRIPTION
## Summary

Resolves the zizmor **auditor** persona findings (`min-severity: low`)
that fail the organisation's required "Audit Workflows" gate and block
Dependabot pull requests from merging.

## Method

- **Boilerplate workflows** (`tag-push`, `release-drafter`) that carried
  findings were replaced byte-for-byte with the canonical versions from
  `actions-template`. This adds the workflow-level `concurrency` group
  (`concurrency-limits`), harden-runner block-mode egress via
  `harden-runner-block-action`, and documented permission scopes
  (`undocumented-permissions`).
- **Repository-specific workflows** were adjusted in place to match the
  canonical patterns: `${{ ... }}` expressions hoisted out of `run:`
  blocks into intermediate environment variables
  (`template-injection`), workflow-level `concurrency` groups
  (`concurrency-limits`), `persist-credentials: false` on checkout
  steps (`artipacked`) where flagged, and explanatory comments on
  permission scopes (`undocumented-permissions`).

Verified with `zizmor --persona auditor --min-severity low` (clean),
with no action pin downgrades.
